### PR TITLE
Color overhaul

### DIFF
--- a/examples/editor.zig
+++ b/examples/editor.zig
@@ -148,9 +148,9 @@ pub fn main() !void {
         helpCb,
         null,
     );
-    
+
     var item = mymenu.asMenu().findItem("&File/Quit...\t");
-    item.setLabelColor(enums.Color.from_rgbi(enums.Color.Red));
+    item.setLabelColor(enums.Color.fromRgbi(enums.Color.Red));
 
     try app.run();
 }

--- a/examples/editormsgs.zig
+++ b/examples/editormsgs.zig
@@ -103,7 +103,7 @@ pub fn main() !void {
     );
 
     var item = mymenu.asMenu().findItem("&File/Quit...\t");
-    item.setLabelColor(enums.Color.from_rgbi(enums.Color.Red));
+    item.setLabelColor(enums.Color.fromRgbi(enums.Color.Red));
 
     while (app.wait()) {
         if (app.recv(Message)) |msg| switch (msg) {

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -10,7 +10,7 @@ pub fn butCb(w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
     var mybox = widget.Widget.fromVoidPtr(data);
     mybox.setLabel("Hello World!");
     var but = button.Button.fromWidgetPtr(w); // You can still use a Widget.fromWidgetPtr
-    but.asWidget().setColor(enums.Color.from_rgbi(enums.Color.Cyan));
+    but.asWidget().setColor(enums.Color.fromRgbi(enums.Color.Cyan));
 }
 
 pub fn main() !void {

--- a/src/app.zig
+++ b/src/app.zig
@@ -39,15 +39,15 @@ pub fn setScheme(scheme: Scheme) void {
 }
 
 // Set the boxtype's draw callback
-pub fn setBoxTypeEx(box: enums.BoxType, comptime f: fn (i32, i32, i32, i32, u32) void, ox: i32, oy: i32, ow: i32, oh: i32) void {
+pub fn setBoxTypeEx(box: enums.BoxType, comptime f: fn (i32, i32, i32, i32, enums.Color) void, ox: i32, oy: i32, ow: i32, oh: i32) void {
     c.Fl_set_box_type_cb(@enumToInt(box),
     // The function must be casted into an exported function before passing
-    @ptrCast(fn (i32, i32, i32, i32, u32) callconv(.C) void, f), ox, oy, ow, oh);
+    @ptrCast(*const fn (i32, i32, i32, i32, u32) callconv(.C) void, &f), ox, oy, ow, oh);
 }
 
 // Simplified version of setBoxTypeEx to keep code a bit cleaner when offsets
 // are unneeded
-pub fn setBoxType(box: enums.BoxType, comptime f: fn (i32, i32, i32, i32, u32) void) void {
+pub fn setBoxType(box: enums.BoxType, comptime f: fn (i32, i32, i32, i32, enums.Color) void) void {
     setBoxTypeEx(box, f, 0, 0, 0, 0);
 }
 
@@ -56,6 +56,14 @@ pub fn setBoxType(box: enums.BoxType, comptime f: fn (i32, i32, i32, i32, u32) v
 // same function name, one must be renamed to allow it to be used in Zig
 pub fn copyBoxType(destBox: enums.BoxType, srcBox: enums.BoxType) void {
     c.Fl_set_box_type(@enumToInt(destBox), @enumToInt(srcBox));
+}
+
+pub fn setVisibleFocus(focus: bool) void {
+    c.Fl_set_visible_focus(@boolToInt(focus));
+}
+
+pub fn setColor(idx: u8, col: enums.Color) void {
+    c.Fl_set_color(idx, col.r, col.g, col.b);
 }
 
 pub fn event() enums.Event {

--- a/src/draw.zig
+++ b/src/draw.zig
@@ -4,6 +4,7 @@ const c = @cImport({
 const Font = @import("enums.zig").Font;
 const BoxType = @import("enums.zig").BoxType;
 const Cursor = @import("enums.zig").Cursor;
+const Color = @import("enums.zig").Color;
 
 pub const LineStyle = enum(i32) {
     /// Solid line
@@ -64,88 +65,83 @@ pub const Offscreen = struct {
     }
 };
 
-/// Shows a color map
-pub fn show_colormap(old_color: u32) u32 {
-    c.Fl_show_colormap(old_color);
+/// Shows a color map and returns the selected color
+pub fn showColorMap(old_color: Color) Color {
+    return Color.fromRgbi(c.Fl_show_colormap(old_color.toRgbi()));
 }
 
-/// Sets the color using rgb values
-pub fn set_color_rgb(r: u8, g: u8, b: u8) void {
-    c.Fl_set_color_rgb(r, g, b);
+/// Change the draw color
+pub fn setColor(col: Color) void {
+    c.Fl_set_color_int(col.toRgbi());
 }
 
 /// Gets the last used color
-pub fn get_color() u32 {
-    return c.Fl_get_color();
+pub fn color() Color {
+    return Color.fromRbgi(c.Fl_get_color());
 }
 
 /// Draws a line
-pub fn draw_line(x1: i32, y1: i32, x2: i32, y2: i32) void {
+pub fn line(x1: i32, y1: i32, x2: i32, y2: i32) void {
     c.Fl_line(x1, y1, x2, y2);
 }
 
 /// Draws a point
-pub fn draw_point(x: i32, y: i32) void {
+pub fn point(x: i32, y: i32) void {
     c.Fl_point(x, y);
 }
 
 /// Draws a rectangle
-pub fn draw_rect(x: i32, y: i32, w: i32, h: i32) void {
+pub fn rect(x: i32, y: i32, w: i32, h: i32) void {
     c.Fl_rect(x, y, w, h);
 }
 
 /// Draws a rectangle with border color
-pub fn draw_rect_with_color(x: i32, y: i32, w: i32, h: i32, color: u32) void {
-    c.Fl_rect_with_color(x, y, w, h, color);
+pub fn rectWithColor(x: i32, y: i32, w: i32, h: i32, col: Color) void {
+    c.Fl_rect_with_color(x, y, w, h, col.toRgbi());
 }
 
 /// Draws a non-filled 3-sided polygon
-pub fn draw_loop(x1: i32, y1: i32, x2: i32, y2: i32, x3: i32, y3: i32) void {
+pub fn loop(x1: i32, y1: i32, x2: i32, y2: i32, x3: i32, y3: i32) void {
     c.Fl_loop(x1, y1, x2, y2, x3, y3);
 }
 
 /// Draws a filled rectangle
-pub fn draw_rect_fill(x: i32, y: i32, w: i32, h: i32, color: u32) void {
-    c.Fl_rectf_with_color(x, y, w, h, color);
+pub fn rectFill(x: i32, y: i32, w: i32, h: i32) void {
+    c.Fl_rectf(x, y, w, h);
+}
+
+/// Draws a filled rectangle
+pub fn rectFillWithColor(x: i32, y: i32, w: i32, h: i32, col: Color) void {
+    c.Fl_rectf_with_color(x, y, w, h, col.toRgbi());
 }
 
 /// Draws a focus rectangle
-pub fn draw_focus_rect(x: i32, y: i32, w: i32, h: i32) void {
+pub fn focusRect(x: i32, y: i32, w: i32, h: i32) void {
     c.Fl_focus_rect(x, y, w, h);
 }
 
-/// Sets the drawing color
-pub fn set_draw_rgb_color(r: u8, g: u8, b: u8) void {
-    c.Fl_set_color_rgb(r, g, b);
-}
-
-/// Sets the drawing color
-pub fn set_draw_color(color: u32) void {
-    c.Fl_set_color_int(color);
-}
-
 /// Draws a circle
-pub fn draw_circle(x: f64, y: f64, r: f64) void {
+pub fn circle(x: f64, y: f64, r: f64) void {
     c.Fl_circle(x, y, r);
 }
 
 /// Draws an arc
-pub fn draw_arc(x: i32, y: i32, w: i32, h: i32, a: f64, b: f64) void {
+pub fn arc(x: i32, y: i32, w: i32, h: i32, a: f64, b: f64) void {
     c.Fl_arc(x, y, w, h, a, b);
 }
 
 /// Draws an arc
-pub fn draw_arc2(x: f64, y: f64, r: f64, start: f64, end: f64) void {
+pub fn arc2(x: f64, y: f64, r: f64, start: f64, end: f64) void {
     c.Fl_arc2(x, y, r, start, end);
 }
 
 /// Draws a filled pie
-pub fn draw_pie(x: i32, y: i32, w: i32, h: i32, a: f64, b: f64) void {
+pub fn pie(x: i32, y: i32, w: i32, h: i32, a: f64, b: f64) void {
     c.Fl_pie(x, y, w, h, a, b);
 }
 
 /// Sets the line style
-pub fn set_line_style(style: LineStyle, thickness: i32) void {
+pub fn setLineStyle(style: LineStyle, thickness: i32) void {
     c.Fl_line_style(
         style,
         thickness,
@@ -154,137 +150,121 @@ pub fn set_line_style(style: LineStyle, thickness: i32) void {
 }
 
 /// Limits drawing to a region
-pub fn push_clip(x: i32, y: i32, w: i32, h: i32) void {
+pub fn pushClip(x: i32, y: i32, w: i32, h: i32) void {
     c.Fl_push_clip(x, y, w, h);
 }
 
 /// Puts the drawing back
-pub fn pop_clip() void {
+pub fn popClip() void {
     c.Fl_pop_clip();
 }
 
 /// Sets the clip region
-pub fn set_clip_region(r: Region) void {
+pub fn setClipRegion(r: Region) void {
     c.Fl_set_clip_region(r);
 }
 
 /// Gets the clip region
-pub fn clip_region() Region {
+pub fn clipRegion() Region {
     return c.Fl_clip_region();
 }
 
 /// Pushes an empty clip region onto the stack so nothing will be clipped
-pub fn push_no_clip() void {
+pub fn pushNoClip() void {
     c.Fl_push_no_clip();
 }
 
 /// Returns whether the rectangle intersect with the current clip region
-pub fn not_clipped(x: i32, y: i32, w: i32, h: i32) bool {
+pub fn notClipped(x: i32, y: i32, w: i32, h: i32) bool {
     return c.Fl_not_clipped(x, y, w, h) != 0;
 }
 
 /// Restores the clip region
-pub fn restore_clip() void {
+pub fn resoreClip() void {
     c.Fl_restore_clip();
 }
 
 /// Transforms coordinate using the current transformation matrix
-pub fn transform_x(x: f64, y: f64) f64 {
+pub fn transformX(x: f64, y: f64) f64 {
     return c.Fl_transform_x(x, y);
 }
 
 /// Transforms coordinate using the current transformation matrix
-pub fn transform_y(x: f64, y: f64) f64 {
+pub fn transformY(x: f64, y: f64) f64 {
     return c.Fl_transform_y(x, y);
 }
 
 /// Transforms distance using current transformation matrix
-pub fn transform_dx(x: f64, y: f64) f64 {
+pub fn transformDX(x: f64, y: f64) f64 {
     return c.Fl_transform_dx(x, y);
 }
 
 /// Transforms distance using current transformation matrix
-pub fn transform_dy(x: f64, y: f64) f64 {
+pub fn transformDY(x: f64, y: f64) f64 {
     return c.Fl_transform_dy(x, y);
 }
 
 /// Adds coordinate pair to the vertex list without further transformations
-pub fn transformed_vertex(xf: f64, yf: f64) void {
+pub fn transformedVertex(xf: f64, yf: f64) void {
     c.Fl_transformed_vertex(xf, yf);
 }
 
-/// Draws a filled rectangle
-pub fn draw_rectf(x: i32, y: i32, w: i32, h: i32) void {
-    c.Fl_rectf(x, y, w, h);
-}
-
-/// Draws a filled rectangle with specified RGB color
-pub fn draw_rectf_with_rgb(
-    x: i32,
-    y: i32,
-    w: i32,
-    h: i32,
-    color_r: u8,
-    color_g: u8,
-    color_b: u8,
-) void {
-    c.Fl_rectf_with_rgb(x, y, w, h, color_r, color_g, color_b);
-}
-
 /// Fills a 3-sided polygon. The polygon must be convex
-pub fn draw_polygon(x: i32, y: i32, x1: i32, y1: i32, x2: i32, y2: i32) void {
+pub fn polygon(x: i32, y: i32, x1: i32, y1: i32, x2: i32, y2: i32) void {
     c.Fl_polygon(x, y, x1, y1, x2, y2);
 }
 
 /// Draws a horizontal line from (x,y) to (x1,y)
-pub fn draw_xyline(x: i32, y: i32, x1: i32) void {
+// Maybe the API shouldn't be changed? I think this looks better when following
+// Zig's conventions though
+pub fn lineXY(x: i32, y: i32, x1: i32) void {
     c.Fl_xyline(x, y, x1);
 }
 
 /// Draws a horizontal line from (x,y) to (x1,y), then vertical from (x1,y) to (x1,y2)
-pub fn draw_xyline2(x: i32, y: i32, x1: i32, y2: i32) void {
+pub fn lineXY2(x: i32, y: i32, x1: i32, y2: i32) void {
     c.Fl_xyline2(x, y, x1, y2);
 }
 
 /// Draws a horizontal line from (x,y) to (x1,y), then a vertical from (x1,y) to (x1,y2)
 /// and then another horizontal from (x1,y2) to (x3,y2)
-pub fn draw_xyline3(x: i32, y: i32, x1: i32, y2: i32, x3: i32) void {
+pub fn lineXY3(x: i32, y: i32, x1: i32, y2: i32, x3: i32) void {
     c.Fl_xyline3(x, y, x1, y2, x3);
 }
 
 /// Draws a vertical line from (x,y) to (x,y1)
-pub fn draw_yxline(x: i32, y: i32, y1: i32) void {
+pub fn lineYX(x: i32, y: i32, y1: i32) void {
     c.Fl_yxline(x, y, y1);
 }
 
 /// Draws a vertical line from (x,y) to (x,y1), then a horizontal from (x,y1) to (x2,y1)
-pub fn draw_yxline2(x: i32, y: i32, y1: i32, x2: i32) void {
+pub fn lineYX2(x: i32, y: i32, y1: i32, x2: i32) void {
     c.Fl_yxline2(x, y, y1, x2);
 }
 
 ///  Draws a vertical line from (x,y) to (x,y1) then a horizontal from (x,y1)
 /// to (x2,y1), then another vertical from (x2,y1) to (x2,y3)
-pub fn draw_yxline3(x: i32, y: i32, y1: i32, x2: i32, y3: i32) void {
+pub fn lineYX3(x: i32, y: i32, y1: i32, x2: i32, y3: i32) void {
     c.Fl_yxline3(x, y, y1, x2, y3);
 }
 
 /// Saves the current transformation matrix on the stack
-pub fn push_matrix() void {
+pub fn pushMatrix() void {
     c.Fl_push_matrix();
 }
 
 /// Pops the current transformation matrix from the stack
-pub fn pop_matrix() void {
+pub fn popMatrix() void {
     c.Fl_pop_matrix();
 }
 
 /// Concatenates scaling transformation onto the current one
-pub fn scale_xy(x: f64, y: f64) void {
+pub fn scale(x: f64, y: f64) void {
     c.Fl_scale(x, y);
 }
 
 /// Concatenates scaling transformation onto the current one
-pub fn scale_x(x: f64) void {
+pub fn scale2(x: f64) void {
     c.Fl_scale2(x);
 }
 
@@ -299,27 +279,27 @@ pub fn rotate(d: f64) void {
 }
 
 /// Concatenates another transformation onto the current one
-pub fn mult_matrix(val_a: f64, val_b: f64, val_c: f64, val_d: f64, x: f64, y: f64) void {
+pub fn multMatrix(val_a: f64, val_b: f64, val_c: f64, val_d: f64, x: f64, y: f64) void {
     c.Fl_mult_matrix(val_a, val_b, val_c, val_d, x, y);
 }
 
 /// Starts drawing a list of points. Points are added to the list with fl_vertex()
-pub fn begin_points() void {
+pub fn beginPoints() void {
     c.Fl_begin_points();
 }
 
 /// Starts drawing a list of lines
-pub fn begin_line() void {
+pub fn beginLine() void {
     c.Fl_begin_line();
 }
 
 /// Starts drawing a closed sequence of lines
-pub fn begin_loop() void {
+pub fn beginLoop() void {
     c.Fl_begin_loop();
 }
 
 /// Starts drawing a convex filled polygon
-pub fn begin_polygon() void {
+pub fn beginPolygon() void {
     c.Fl_begin_polygon();
 }
 
@@ -329,27 +309,27 @@ pub fn vertex(x: f64, y: f64) void {
 }
 
 /// Ends list of points, and draws
-pub fn end_points() void {
+pub fn endPoints() void {
     c.Fl_end_points();
 }
 
 /// Ends list of lines, and draws
-pub fn end_line() void {
+pub fn endLine() void {
     c.Fl_end_line();
 }
 
 /// Ends closed sequence of lines, and draws
-pub fn end_loop() void {
+pub fn endLoop() void {
     c.Fl_end_loop();
 }
 
 /// Ends closed sequence of lines, and draws
-pub fn end_polygon() void {
+pub fn endPolygon() void {
     c.Fl_end_polygon();
 }
 
 /// Starts drawing a complex filled polygon
-pub fn begin_complex_polygon() void {
+pub fn beginComplexPolygon() void {
     c.Fl_begin_complex_polygon();
 }
 
@@ -359,12 +339,12 @@ pub fn gap() void {
 }
 
 /// Ends complex filled polygon, and draws
-pub fn end_complex_polygon() void {
+pub fn endComplexPolygon() void {
     c.Fl_end_complex_polygon();
 }
 
 /// Sets the current font, which is then used in various drawing routines
-pub fn set_font(face: Font, fsize: u32) void {
+pub fn setFont(face: Font, fsize: u32) void {
     c.Fl_set_draw_font(@enumToInt(face), fsize);
 }
 
@@ -384,7 +364,7 @@ pub fn height() i32 {
 }
 
 /// Sets the line spacing for the current font
-pub fn set_height(f: Font, sz: u32) void {
+pub fn setHeight(f: Font, sz: u32) void {
     c.Fl_set_height(@enumToInt(f), sz);
 }
 
@@ -404,79 +384,79 @@ pub fn width2(txt: [*c]const u8, n: i32) f64 {
 }
 
 /// Returns the typographical width of a single character
-pub fn char_width(val: u8) f64 {
+pub fn charWidth(val: u8) f64 {
     return c.Fl_width3(val);
 }
 
 /// Converts text from Windows/X11 latin1 character set to local encoding
-pub fn latin1_to_local(txt: [*c]const u8, n: i32) [*c]const u8 {
+pub fn latin1ToLocal(txt: [*c]const u8, n: i32) [*c]const u8 {
     return c.Fl_latin1_to_local(txt, n);
 }
 
 /// Converts text from local encoding to Windowx/X11 latin1 character set
-pub fn local_to_latin1(txt: [*c]const u8, n: i32) [*c]const u8 {
+pub fn localToLatin1(txt: [*c]const u8, n: i32) [*c]const u8 {
     return c.Fl_local_to_latin1(txt, n);
 }
 
 /// Draws a string starting at the given x, y location
-pub fn draw_text(txt: [*c]const u8, x: i32, y: i32) void {
+pub fn drawText(txt: [*c]const u8, x: i32, y: i32) void {
     c.Fl_draw(txt, x, y);
 }
 
 /// Draws a string starting at the given x, y location with width and height and alignment
-pub fn draw_text2(string: [*c]const u8, x: i32, y: i32, w: i32, h: i32, al: i32) void {
+pub fn drawText2(string: [*c]const u8, x: i32, y: i32, w: i32, h: i32, al: i32) void {
     c.Fl_draw_text2(string, x, y, w, h, al);
 }
 
 /// Draws a string starting at the given x, y location, rotated to an angle
-pub fn draw_text_angled(angle: i32, txt: [*c]const u8, x: i32, y: i32) void {
+pub fn drawTextAngled(angle: i32, txt: [*c]const u8, x: i32, y: i32) void {
     c.Fl_draw2(angle, txt, x, y);
 }
 
 /// Draws a frame with text
-pub fn draw_frame(string: [*c]const u8, x: i32, y: i32, w: i32, h: i32) void {
+pub fn drawFrame(string: [*c]const u8, x: i32, y: i32, w: i32, h: i32) void {
     c.Fl_frame(string, x, y, w, h);
 }
 
 /// Draws a frame with text.
 /// Differs from frame() by the order of the line segments
-pub fn draw_frame2(string: [*c]const u8, x: i32, y: i32, w: i32, h: i32) void {
+pub fn drawFrame2(string: [*c]const u8, x: i32, y: i32, w: i32, h: i32) void {
     c.Fl_frame2(string, x, y, w, h);
 }
 
 /// Draws a box given the box type, size, position and color
-pub fn draw_box(box_type: BoxType, x: i32, y: i32, w: i32, h: i32, color: u32) void {
-    c.Fl_draw_box(box_type, x, y, w, h, color);
+pub fn drawBox(box_type: BoxType, x: i32, y: i32, w: i32, h: i32, col: Color) void {
+    c.Fl_draw_box(box_type, x, y, w, h, col.toRgbi());
 }
 
 /// Checks whether platform supports true alpha blending for RGBA images
-pub fn can_do_alpha_blending() bool {
+pub fn canDoAlphaBlending() bool {
     return c.Fl_can_do_alpha_blending() != 0;
 }
 
 /// Get a human-readable string from a shortcut value
-pub fn shortcut_label(shortcut: i32) [*c]const u8 {
+pub fn shortcutLabel(shortcut: i32) [*c]const u8 {
     return c.Fl_shortcut_label(shortcut);
 }
 
 /// Draws a selection rectangle, erasing a previous one by XOR'ing it first.
-pub fn overlay_rect(x: i32, y: i32, w: i32, h: i32) void {
+pub fn overlayRect(x: i32, y: i32, w: i32, h: i32) void {
     c.Fl_overlay_rect(x, y, w, h);
 }
 
 /// Erase a selection rectangle without drawing a new one
-pub fn overlay_clear() void {
+pub fn overlayClear() void {
     c.Fl_overlay_clear();
 }
 
 /// Sets the cursor style
-pub fn set_cursor(cursor: Cursor) void {
+pub fn setCursor(cursor: Cursor) void {
     c.Fl_set_cursor(@enumToInt(cursor));
 }
 
 /// Sets the cursor style
-pub fn set_cursor_with_color(cursor: Cursor, fg: u32, bg: u32) void {
-    c.Fl_set_cursor2(@enumToInt(cursor), @enumToInt(fg), @enumToInt(bg));
+pub fn setCursorWithColor(cursor: Cursor, fg: Color, bg: Color) void {
+    c.Fl_set_cursor2(@enumToInt(cursor), fg.toRgbi(), bg.toRgbi());
 }
 
 test "all" {

--- a/src/group.zig
+++ b/src/group.zig
@@ -69,23 +69,23 @@ pub const Group = struct {
         c.Fl_Group_end(self.inner);
     }
 
-    pub fn find(self: *const Group, w: *widget.Widget) u32 {
+    pub fn find(self: *const Group, w: *const widget.Widget) u32 {
         return c.Fl_Group_find(self.inner, w.*.raw());
     }
 
-    pub fn add(self: *const Group, w: *widget.Widget) void {
+    pub fn add(self: *const Group, w: *const widget.Widget) void {
         return c.Fl_Group_add(self.inner, w.*.raw());
     }
 
-    pub fn insert(self: *const Group, w: *widget.Widget, index: u32) void {
+    pub fn insert(self: *const Group, w: *const widget.Widget, index: u32) void {
         return c.Fl_Group_insert(self.inner, w.*.raw(), index);
     }
 
-    pub fn remove(self: *const Group, w: *widget.Widget) void {
+    pub fn remove(self: *const Group, w: *const widget.Widget) void {
         return c.Fl_Group_remove(self.inner, w.*.raw());
     }
 
-    pub fn resizable(self: *const Group, w: *widget.Widget) void {
+    pub fn resizable(self: *const Group, w: *const widget.Widget) void {
         return c.Fl_Group_resizable(self.inner, w.*.raw());
     }
 

--- a/src/menu.zig
+++ b/src/menu.zig
@@ -118,7 +118,7 @@ pub const Menu = struct {
     }
 
     pub fn setTextColor(self: *const Menu, col: enums.Color) void {
-        c.Fl_Menu_Bar_set_text_color(self.inner, col.inner());
+        c.Fl_Menu_Bar_set_text_color(self.inner, col.toRgbi());
     }
 
     pub fn setTextSize(self: *const Menu, sz: u32) void {
@@ -308,15 +308,15 @@ pub const MenuItem = struct {
     }
 
     pub fn color(self: *const MenuItem) enums.Color {
-        return enums.Color.from_rgbi(c.Fl_Menu_Item_color(self.inner));
+        return enums.Color.fromRgbi(c.Fl_Menu_Item_color(self.inner));
     }
 
     pub fn labelColor(self: *const MenuItem) enums.Color {
-        return enums.Color.from_rgbi(c.Fl_Menu_Item_label_color(self.inner));
+        return enums.Color.fromRgbi(c.Fl_Menu_Item_label_color(self.inner));
     }
 
     pub fn setLabelColor(self: *const MenuItem, col: enums.Color) void {
-        c.Fl_Menu_Item_set_label_color(self.inner, col.inner());
+        c.Fl_Menu_Item_set_label_color(self.inner, col.toRgbi());
     }
 
     pub fn labelFont(self: *const MenuItem) enums.Font {

--- a/src/widget.zig
+++ b/src/widget.zig
@@ -3,6 +3,7 @@ const c = @cImport({
     @cInclude("cfl.h");
 });
 const enums = @import("enums.zig");
+const Color = enums.Color;
 const group = @import("group.zig");
 const image = @import("image.zig");
 
@@ -62,8 +63,8 @@ pub const Widget = struct {
         self.setCallback(shim, @intToPtr(?*anyopaque, @enumToInt(msg)));
     }
 
-    pub fn setColor(self: *const Widget, col: enums.Color) void {
-        c.Fl_Widget_set_color(self.inner, col.inner());
+    pub fn setColor(self: *const Widget, col: Color) void {
+        c.Fl_Widget_set_color(self.inner, col.toRgbi());
     }
 
     pub fn show(self: *const Widget) void {
@@ -114,16 +115,16 @@ pub const Widget = struct {
         c.Fl_Widget_set_type(self.inner, @enumToInt(t));
     }
 
-    pub fn color(self: *const Widget) enums.Color {
-        return enums.Color.from_rgbi(c.Fl_Widget_color(self.inner));
+    pub fn color(self: *const Widget) Color {
+        return Color.fromRgbi(c.Fl_Widget_color(self.inner));
     }
 
-    pub fn labelColor(self: *const Widget) enums.Color {
-        return enums.Color.from_rgbi(c.Fl_Widget_label_color(self.inner));
+    pub fn labelColor(self: *const Widget) Color {
+        return Color.fromRbgi(c.Fl_Widget_label_color(self.inner));
     }
 
-    pub fn setLabelColor(self: *const Widget, col: enums.Color) void {
-        c.Fl_Widget_set_label_color(self.inner, col.inner());
+    pub fn setLabelColor(self: *const Widget, col: Color) void {
+        c.Fl_Widget_set_label_color(self.inner, col.toRbgi());
     }
 
     pub fn labelFont(self: *const Widget) enums.Font {
@@ -183,7 +184,7 @@ pub const Widget = struct {
     }
 
     pub fn setSelectionColor(self: *const Widget, col: enums.Color) void {
-        c.Fl_Widget_set_selection_color(self.inner, col.inner());
+        c.Fl_Widget_set_selection_color(self.inner, col.toRgbi());
     }
 
     pub fn doCallback(self: *const Widget) void {


### PR DESCRIPTION
The `enums.Color` is now a packed struct made of R, G, B and I u8 elements, which allows for casting straight to a u32, along with easy field access to each color value.

A couple functions have also been updated to build on the latest Zig and most functions that require a color param have been updated to accept the new Color type