### PR TITLE
Various API changes (listed in extended description)

### DIFF
--- a/examples/editor.zig
+++ b/examples/editor.zig
@@ -1,6 +1,7 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
 const widget = zfltk.widget;
+const Widget = widget.Widget;
 const window = zfltk.window;
 const menu = zfltk.menu;
 const enums = zfltk.enums;
@@ -9,20 +10,19 @@ const dialog = zfltk.dialog;
 
 // To avoid exiting when hitting escape.
 // Also logic can be added to prompt the user to save their work
-pub fn winCb(w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
-    _ = data;
+pub fn winCb(w: Widget) void {
     if (app.event() == enums.Event.Close) {
-        widget.Widget.fromWidgetPtr(w).hide();
+        w.hide();
     }
 }
 
-pub fn newCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn newCb(w: Widget, data: ?*anyopaque) void {
     _ = w;
     var buf = text.TextBuffer.fromVoidPtr(data);
     buf.setText("");
 }
 
-pub fn openCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn openCb(w: Widget, data: ?*anyopaque) void {
     _ = w;
     var dlg = dialog.NativeFileDialog.new(.BrowseFile);
     dlg.setFilter("*.{txt,zig}");
@@ -34,7 +34,7 @@ pub fn openCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
     }
 }
 
-pub fn saveCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn saveCb(w: Widget, data: ?*anyopaque) void {
     _ = w;
     var dlg = dialog.NativeFileDialog.new(.BrowseSaveFile);
     dlg.setFilter("*.{txt,zig}");
@@ -46,31 +46,31 @@ pub fn saveCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
     }
 }
 
-pub fn quitCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn quitCb(w: Widget, data: ?*anyopaque) void {
     _ = w;
     var win = widget.Widget.fromVoidPtr(data);
     win.hide();
 }
 
-pub fn cutCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn cutCb(w: Widget, data: ?*anyopaque) void {
     _ = w;
     const editor = text.TextEditor.fromVoidPtr(data);
     editor.cut();
 }
 
-pub fn copyCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn copyCb(w: Widget, data: ?*anyopaque) void {
     _ = w;
     const editor = text.TextEditor.fromVoidPtr(data);
     editor.copy();
 }
 
-pub fn pasteCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn pasteCb(w: Widget, data: ?*anyopaque) void {
     _ = w;
     const editor = text.TextEditor.fromVoidPtr(data);
     editor.paste();
 }
 
-pub fn helpCb(w: menu.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn helpCb(w: Widget, data: ?*anyopaque) void {
     _ = w;
     _ = data;
     dialog.message(300, 200, "This editor was built using fltk and zig!");
@@ -89,59 +89,61 @@ pub fn main() !void {
     editor.asTextDisplay().setBuffer(&buf);
     editor.asTextDisplay().setLinenumberWidth(24);
     win.asGroup().end();
+    win.asGroup().add(&editor.asWidget());
+    win.asGroup().resizable(&editor.asWidget());
     win.asWidget().show();
-    win.asWidget().setCallback(winCb, null);
+    win.asWidget().setCallback(winCb);
 
-    mymenu.asMenu().add(
+    mymenu.asMenu().addEx(
         "&File/New...\t",
         enums.Shortcut.Ctrl | 'n',
         .Normal,
         newCb,
         buf.toVoidPtr(),
     );
-    mymenu.asMenu().add(
+    mymenu.asMenu().addEx(
         "&File/Open...\t",
         enums.Shortcut.Ctrl | 'o',
         .Normal,
         openCb,
         buf.toVoidPtr(),
     );
-    mymenu.asMenu().add(
+    mymenu.asMenu().addEx(
         "&File/Save...\t",
         enums.Shortcut.Ctrl | 's',
         .MenuDivider,
         saveCb,
         buf.toVoidPtr(),
     );
-    mymenu.asMenu().add(
+    mymenu.asMenu().addEx(
         "&File/Quit...\t",
         enums.Shortcut.Ctrl | 'q',
         .Normal,
         quitCb,
         win.toVoidPtr(),
     );
-    mymenu.asMenu().add(
+    mymenu.asMenu().addEx(
         "&Edit/Cut...\t",
         enums.Shortcut.Ctrl | 'x',
         .Normal,
         cutCb,
         editor.toVoidPtr(),
     );
-    mymenu.asMenu().add(
+    mymenu.asMenu().addEx(
         "&Edit/Copy...\t",
         enums.Shortcut.Ctrl | 'c',
         .Normal,
         copyCb,
         editor.toVoidPtr(),
     );
-    mymenu.asMenu().add(
+    mymenu.asMenu().addEx(
         "&Edit/Paste...\t",
         enums.Shortcut.Ctrl | 'v',
         .Normal,
         pasteCb,
         editor.toVoidPtr(),
     );
-    mymenu.asMenu().add(
+    mymenu.asMenu().addEx(
         "&Help/About...\t",
         enums.Shortcut.Ctrl | 'q',
         .Normal,

--- a/examples/editormsgs.zig
+++ b/examples/editormsgs.zig
@@ -1,6 +1,7 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
 const widget = zfltk.widget;
+const Widget = widget.Widget;
 const window = zfltk.window;
 const menu = zfltk.menu;
 const enums = zfltk.enums;
@@ -21,9 +22,8 @@ pub const Message = enum(usize) {
 
 // To avoid exiting when hitting escape.
 // Also logic can be added to prompt the user to save their work
-pub fn winCb(w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn winCb(w: Widget) void {
     _ = w;
-    _ = data;
     if (app.event() == enums.Event.Close) {
         app.send(Message, .Quit);
     }
@@ -43,7 +43,7 @@ pub fn main() !void {
     editor.asTextDisplay().setLinenumberWidth(24);
     win.asGroup().end();
     win.asWidget().show();
-    win.asWidget().setCallback(winCb, null);
+    win.asWidget().setCallback(winCb);
 
     mymenu.asMenu().add_emit(
         "&File/New...\t",

--- a/examples/input.zig
+++ b/examples/input.zig
@@ -14,9 +14,9 @@ const ButtonMessage = enum(usize) {
     Released,
 };
 
-pub fn butCb(w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32 {
-    _ = w;
+pub fn butCb(w: widget.Widget, ev: i32, data: ?*anyopaque) i32 {
     _ = data;
+    _ = w;
     switch (@intToEnum(Event, ev)) {
         Event.Push => {
             app.send(ButtonMessage, .Pushed);
@@ -26,7 +26,7 @@ pub fn butCb(w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32 {
             app.send(ButtonMessage, .Released);
             return 1;
         },
-        else => return 0,    
+        else => return 0,
     }
     return 0;
 }

--- a/examples/layout.zig
+++ b/examples/layout.zig
@@ -17,6 +17,8 @@ pub fn main() !void {
     _ = button.Button.new(0, 0, 0, 40, "Button 1");
     _ = button.Button.new(0, 0, 0, 40, "Button 2");
     _ = button.Button.new(0, 0, 0, 40, "Button 3");
+    win.asGroup().add(&pack.asWidget());
+    win.asGroup().resizable(&pack.asWidget());
     pack.asGroup().end();
     win.asGroup().end();
     win.asWidget().show();

--- a/examples/mixed.zig
+++ b/examples/mixed.zig
@@ -5,14 +5,14 @@ const c = @cImport({
 const zfltk = @import("zfltk");
 const app = zfltk.app;
 const widget = zfltk.widget;
+const Widget = widget.Widget;
 const window = zfltk.window;
 const button = zfltk.button;
 const std = @import("std");
 
-pub fn butCb(w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn butCb(w: Widget) void {
     _ = w;
-    _ = data;
-    std.debug.print("{},{}\n", .{c.Fl_event_x(), c.Fl_event_y()});
+    std.debug.print("{},{}\n", .{ c.Fl_event_x(), c.Fl_event_y() });
 }
 
 pub fn main() !void {
@@ -21,6 +21,6 @@ pub fn main() !void {
     var but = button.Button.new(160, 200, 80, 40, "Click");
     win.asGroup().end();
     win.asWidget().show();
-    but.asWidget().setCallback(butCb, null);
+    but.asWidget().setCallback(butCb);
     try app.run();
 }

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -1,15 +1,16 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
 const widget = zfltk.widget;
+const Widget = widget.Widget;
 const window = zfltk.window;
 const button = zfltk.button;
 const box = zfltk.box;
 const enums = zfltk.enums;
 
-pub fn butCb(w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn butCb(w: Widget, data: ?*anyopaque) void {
     var mybox = widget.Widget.fromVoidPtr(data);
     mybox.setLabel("Hello World!");
-    var but = button.Button.fromWidgetPtr(w); // You can still use a Widget.fromWidgetPtr
+    var but = button.Button.fromWidgetPtr(w.inner); // You can still use a Widget.fromWidgetPtr
     but.asWidget().setColor(enums.Color.fromRgbi(enums.Color.Cyan));
 }
 
@@ -24,6 +25,6 @@ pub fn main() !void {
     mybox.asWidget().setLabelSize(18);
     win.asGroup().end();
     win.asWidget().show();
-    but.asWidget().setCallback(butCb, mybox.toVoidPtr());
+    but.asWidget().setCallbackEx(butCb, mybox.toVoidPtr());
     try app.run();
 }

--- a/examples/threadawake.zig
+++ b/examples/threadawake.zig
@@ -23,9 +23,11 @@ pub fn thread_func(data: ?*anyopaque) !void {
     }
 }
 
-pub fn butCb(w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void {
+pub fn butCb(w: widget.Widget, data: ?*anyopaque) void {
     _ = w;
-    var thread = std.Thread.spawn(.{}, thread_func, .{data}) catch { return; };
+    var thread = std.Thread.spawn(.{}, thread_func, .{data}) catch {
+        return;
+    };
     thread.detach();
 }
 
@@ -38,6 +40,6 @@ pub fn main() !void {
     var mybox = box.Box.new(10, 10, 380, 180, "");
     win.asGroup().end();
     win.asWidget().show();
-    but.asWidget().setCallback(butCb, mybox.toVoidPtr());
+    but.asWidget().setCallbackEx(butCb, mybox.toVoidPtr());
     try app.run();
 }

--- a/src/button.zig
+++ b/src/button.zig
@@ -2,6 +2,7 @@ const c = @cImport({
     @cInclude("cfl_button.h");
 });
 const widget = @import("widget.zig");
+const Widget = widget.Widget;
 const enums = @import("enums.zig");
 
 pub const Button = struct {
@@ -46,11 +47,11 @@ pub const Button = struct {
         };
     }
 
-    pub fn handle(self: *const Button, comptime cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
+    pub fn handle(self: *const Button, comptime cb: fn (w: Widget, ev: i32, data: ?*anyopaque) i32, data: ?*anyopaque) void {
         c.Fl_Button_handle(self.inner, @ptrCast(c.custom_handler_callback, &cb), data);
     }
 
-    pub fn draw(self: *const Button, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+    pub fn draw(self: *const Button, cb: fn (w: Widget, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
         c.Fl_Button_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
     }
 
@@ -188,11 +189,11 @@ pub const CheckButton = struct {
         };
     }
 
-    pub fn handle(self: *const CheckButton, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
+    pub fn handle(self: *const CheckButton, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) i32, data: ?*anyopaque) void {
         c.Fl_Check_Button_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
     }
 
-    pub fn draw(self: *const CheckButton, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+    pub fn draw(self: *const CheckButton, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) void, data: ?*anyopaque) void {
         c.Fl_Check_Button_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
     }
 };

--- a/src/group.zig
+++ b/src/group.zig
@@ -2,6 +2,7 @@ const c = @cImport({
     @cInclude("cfl_group.h");
 });
 const widget = @import("widget.zig");
+const Widget = widget.Widget;
 
 pub const GroupPtr = ?*c.Fl_Group;
 
@@ -226,11 +227,15 @@ pub const Tabs = struct {
         };
     }
 
-    pub fn handle(self: *const Tabs, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
+    pub fn setHandle(self: *const Tabs, cb: fn (w: Widget, ev: i32) i32) void {
+        c.Fl_Tabs_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), null);
+    }
+
+    pub fn setHandleEx(self: *const Tabs, cb: fn (w: Widget, ev: i32, data: ?*anyopaque) i32, data: ?*anyopaque) void {
         c.Fl_Tabs_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
     }
 
-    pub fn draw(self: *const Tabs, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+    pub fn draw(self: *const Tabs, cb: fn (w: Widget, data: ?*anyopaque) void, data: ?*anyopaque) void {
         c.Fl_Tabs_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
     }
 
@@ -331,7 +336,6 @@ pub const Scroll = struct {
     }
 };
 
-
 pub const FlexType = enum(i32) {
     Vertical = 0,
     Horizontal = 1,
@@ -389,16 +393,16 @@ pub const Flex = struct {
         };
     }
 
-    pub fn handle(self: *const Flex, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
+    pub fn handle(self: *const Flex, cb: fn (w: Widget, ev: i32, data: ?*anyopaque) i32, data: ?*anyopaque) void {
         c.Fl_Flex_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
     }
 
-    pub fn draw(self: *const Flex, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+    pub fn draw(self: *const Flex, cb: fn (w: Widget, data: ?*anyopaque) void, data: ?*anyopaque) void {
         c.Fl_Flex_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
     }
 
     /// Set the size of the child
-    pub fn fixed(self: *const Flex, w: *const widget.Widget, sz: i32) void {
+    pub fn fixed(self: *const Flex, w: *const Widget, sz: i32) void {
         c.Fl_Flex_set_size(self.inner, @ptrCast(*c.Fl_Widget, w.*.raw()), sz);
     }
 

--- a/src/input.zig
+++ b/src/input.zig
@@ -2,7 +2,11 @@ const c = @cImport({
     @cInclude("cfl_input.h");
 });
 const widget = @import("widget.zig");
+const Widget = widget.Widget;
 const enums = @import("enums.zig");
+const Event = enums.Event;
+const Color = enums.Color;
+const Font = enums.Font;
 
 pub const Input = struct {
     inner: ?*c.Fl_Input,
@@ -46,8 +50,12 @@ pub const Input = struct {
         };
     }
 
-    pub fn handle(self: *const Input, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Input_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
+    pub fn setHandle(self: *const Input, comptime f: fn (w: Widget, ev: Event) bool) void {
+        c.Fl_Input_handle(self.inner, @ptrCast(c.custom_handler_callback, &f), null);
+    }
+
+    pub fn setHandleEx(self: *const Input, comptime f: fn (w: Widget, ev: Event, data: ?*anyopaque) i32, data: ?*anyopaque) void {
+        c.Fl_Input_handle(self.inner, @ptrCast(c.custom_handler_callback, &f), data);
     }
 
     pub fn draw(self: *const Input, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
@@ -58,19 +66,32 @@ pub const Input = struct {
         return c.Fl_Input_value(self.inner);
     }
 
-    pub fn setValue(self: *const Input, val: [*c]const u8) void {
-        c.Fl_Input_set_value(self.inner, val);
+    pub fn insert(self: *const Input, val: [*c]const u8, idx: u16) !void {
+        _ = c.Fl_Input_insert(self.inner, val, idx);
     }
 
-    pub fn setTextFont(self: *const Input, font: enums.Font) void {
+    // TODO: handle errors
+    pub fn setValue(self: *const Input, val: [*c]const u8) !void {
+        _ = c.Fl_Input_set_value(self.inner, val);
+    }
+
+    pub fn position(self: *const Input) u16 {
+        return @intCast(u16, c.Fl_Input_position(self.inner));
+    }
+
+    pub fn setPosition(self: *const Input, sz: u16) !void {
+        _ = c.Fl_Input_set_position(self.inner, sz);
+    }
+
+    pub fn setTextFont(self: *const Input, font: Font) void {
         c.Fl_Input_set_text_font(self.inner, @enumToInt(font));
     }
 
-    pub fn setTextColor(self: *const Input, col: enums.Color) void {
+    pub fn setTextColor(self: *const Input, col: Color) void {
         c.Fl_Input_set_text_color(self.inner, col.inner());
     }
 
-    pub fn setTextSize(self: *const Input, sz: u32) void {
+    pub fn setTextSize(self: *const Input, sz: i32) void {
         c.Fl_Input_set_text_size(self.inner, sz);
     }
 };

--- a/src/menu.zig
+++ b/src/menu.zig
@@ -3,6 +3,7 @@ const c = @cImport({
     @cInclude("cfl_menu.h");
 });
 const widget = @import("widget.zig");
+const Widget = widget.Widget;
 const enums = @import("enums.zig");
 
 pub const WidgetPtr = ?*c.Fl_Widget;
@@ -85,8 +86,12 @@ pub const Menu = struct {
         c.Fl_Menu_Bar_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
     }
 
-    pub fn add(self: *const Menu, name: [*c]const u8, shortcut: i32, flag: MenuFlag, comptime cb: fn (w: ?*c.Fl_Widget, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        _ = c.Fl_Menu_Bar_add(self.inner, name, shortcut, cb, data, @enumToInt(flag));
+    pub fn add(self: *const Menu, name: [*c]const u8, shortcut: i32, flag: MenuFlag, comptime f: fn (w: Widget) void, data: ?*anyopaque) void {
+        _ = c.Fl_Menu_Bar_add(self.inner, name, shortcut, @ptrCast(*const fn (?*c.Fl_Widget, ?*anyopaque) callconv(.C) void, &f), data, @enumToInt(flag));
+    }
+
+    pub fn addEx(self: *const Menu, name: [*c]const u8, shortcut: i32, flag: MenuFlag, comptime f: fn (w: Widget, data: ?*anyopaque) void, data: ?*anyopaque) void {
+        _ = c.Fl_Menu_Bar_add(self.inner, name, shortcut, @ptrCast(*const fn (?*c.Fl_Widget, ?*anyopaque) callconv(.C) void, &f), data, @enumToInt(flag));
     }
 
     pub fn insert(self: *const Menu, idx: u32, name: [*c]const u8, shortcut: i32, flag: MenuFlag, cb: fn (w: ?*c.Fl_Widget, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {

--- a/src/text.zig
+++ b/src/text.zig
@@ -200,11 +200,11 @@ pub const TextDisplay = struct {
         c.Fl_Text_Display_set_text_color(self.inner, col.inner());
     }
 
-    pub fn setTextSize(self: *const TextDisplay, sz: u32) void {
+    pub fn setTextSize(self: *const TextDisplay, sz: i32) void {
         c.Fl_Text_Display_set_text_size(self.inner, sz);
     }
 
-    pub fn scroll(self: *const TextDisplay, topLineNum: u32, horizOffset: u32) void {
+    pub fn scroll(self: *const TextDisplay, topLineNum: i32, horizOffset: i32) void {
         c.Fl_Text_Display_scroll(self.inner, topLineNum, horizOffset);
     }
 


### PR DESCRIPTION
* Change callback function to use `Widget` instead of `WidgetPtr` and no longer require to be callconv(.C)
* Make editor examples resizable
* Add wrappers for loading font files
* Add eventKey
* Add timeout funcs
* Fix issue when setting black color (would instead use FLTK's foreground color)
* Add darken and lighten funcs for colors
* Add setValue, insert, position and setPosition for input
* Replace funcs that take i32 with u16 where negative numbers are undefined
* Rename getAlign to labelAlign to keep it consistent with the rest of the beindings
* Rename visibleFocus to setVisibleFocus as it's a setter func
* Add example showing custom draw funcs