### PR TITLE
Ziggifying the API

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -8,7 +8,7 @@ pub const Example = struct {
     output: []const u8,
     input: []const u8,
 
-    pub fn new(output: []const u8, input: []const u8, desc: ?[]const u8) Example {
+    pub fn init(output: []const u8, input: []const u8, desc: ?[]const u8) Example {
         return Example{
             .description = desc,
             .output = output,
@@ -18,19 +18,21 @@ pub const Example = struct {
 };
 
 const examples = &[_]Example{
-    Example.new("simple", "examples/simple.zig", "A simple hello world app"),
-    Example.new("capi", "examples/capi.zig", "Using the C-api directly"),
-    Example.new("image", "examples/image.zig", "Simple image example"),
-    Example.new("input", "examples/input.zig", "Simple input example"),
-    Example.new("mixed", "examples/mixed.zig", "Mixing both c and zig apis"),
-    Example.new("editor", "examples/editor.zig", "More complex example"),
-    Example.new("layout", "examples/layout.zig", "Layout example"),
-    Example.new("valuators", "examples/valuators.zig", "valuators example"),
-    Example.new("channels", "examples/channels.zig", "Use messages to handle events"),
-    Example.new("editormsgs", "examples/editormsgs.zig", "Use messages in the editor example"),
-    Example.new("browser", "examples/browser.zig", "Browser example"),
-    Example.new("flex", "examples/flex.zig", "Flex example"),
-    Example.new("threadawake", "examples/threadawake.zig", "Thread awake example"),
+    Example.init("simple", "examples/simple.zig", "A simple hello world app"),
+    Example.init("capi", "examples/capi.zig", "Using the C-api directly"),
+    Example.init("customwidget", "examples/customwidget.zig", "Custom widget example"),
+    Example.init("image", "examples/image.zig", "Simple image example"),
+    Example.init("input", "examples/input.zig", "Simple input example"),
+    Example.init("mixed", "examples/mixed.zig", "Mixing both c and zig apis"),
+    Example.init("editor", "examples/editor.zig", "More complex example"),
+    Example.init("layout", "examples/layout.zig", "Layout example"),
+    Example.init("valuators", "examples/valuators.zig", "valuators example"),
+    Example.init("channels", "examples/channels.zig", "Use messages to handle events"),
+    // Disable until this example is updated to the new API
+    //    Example.init("editormsgs", "examples/editormsgs.zig", "Use messages in the editor example"),
+    Example.init("browser", "examples/browser.zig", "Browser example"),
+    Example.init("flex", "examples/flex.zig", "Flex example"),
+    Example.init("threadawake", "examples/threadawake.zig", "Thread awake example"),
 };
 
 pub fn build(b: *Builder) !void {
@@ -55,4 +57,3 @@ pub fn build(b: *Builder) !void {
         run_step.dependOn(&run_cmd.step);
     }
 }
-

--- a/examples/browser.zig
+++ b/examples/browser.zig
@@ -1,25 +1,39 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
-const window = zfltk.window;
-const browser = zfltk.browser;
+const Window = zfltk.Window;
+const Browser = zfltk.Browser;
 
 pub fn main() !void {
     try app.init();
-    var win = window.Window.new(200, 200, 900, 300, "");
-    var mybrowser = browser.MultiBrowser.new(10, 10, 900 - 20, 300 - 20, "");
-    const widths = [_:0]i32{50, 50, 50, 70, 70, 40, 40, 70, 70, 50};
-    var b = mybrowser.asBrowser();
-    b.setColumnWidths(&widths);
-    b.setColumnChar('\t');
-    b.add("USER\tPID\t%CPU\t%MEM\tVSZ\tRSS\tTTY\tSTAT\tSTART\tTIME\tCOMMAND");
-    b.add("root\t2888\t0.0\t0.0\t1352\t0\ttty3\tSW\tAug15\t0:00\t@b@f/sbin/mingetty tty3");
-    b.add("erco\t2889\t0.0\t13.0\t221352\t0\ttty3\tR\tAug15\t1:34\t@b@f/usr/local/bin/render a35 0004");
-    b.add("uucp\t2892\t0.0\t0.0\t1352\t0\tttyS0\tSW\tAug15\t0:00\t@b@f/sbin/agetty -h 19200 ttyS0 vt100");
-    b.add("root\t13115\t0.0\t0.0\t1352\t0\ttty2\tSW\tAug30\t0:00\t@b@f/sbin/mingetty tty2");
-    b.add(
-        "root\t13464\t0.0\t0.0\t1352\t0\ttty1\tSW\tAug30\t0:00\t@b@f/sbin/mingetty tty1 --noclear",
+    var win = try Window.init(.{
+        .w = 900,
+        .h = 300,
+        .label = "Browser demo",
+    });
+
+    // Available browsers are: normal, select, hold, multi and file
+    var browser = try Browser(.multi).init(.{
+        .x = 10,
+        .y = 10,
+        .w = 900 - 20,
+        .h = 300 - 20,
+    });
+
+    browser.setColumnWidths(
+        &[_:0]i32{ 50, 50, 50, 70, 70, 50, 50, 70, 70, 50 },
     );
-    win.asGroup().end();
-    win.asWidget().show();
+
+    browser.setColumnChar('\t');
+    browser.add("USER\tPID\t%CPU\t%MEM\tVSZ\tRSS\tTTY\tSTAT\tSTART\tTIME\tCOMMAND");
+    browser.add("root\t2888\t0.0\t0.0\t1352\t0\ttty3\tSW\tAug15\t0:00\t@b@f/sbin/mingetty tty3");
+    browser.add("erco\t2889\t0.0\t13.0\t221352\t0\ttty3\tR\tAug15\t1:34\t@b@f/usr/local/bin/render a35 0004");
+    browser.add("uucp\t2892\t0.0\t0.0\t1352\t0\tttyS0\tSW\tAug15\t0:00\t@b@f/sbin/agetty -h 19200 ttyS0 vt100");
+    browser.add("root\t13115\t0.0\t0.0\t1352\t0\ttty2\tSW\tAug30\t0:00\t@b@f/sbin/mingetty tty2");
+    browser.add("root\t13464\t0.0\t0.0\t1352\t0\ttty1\tSW\tAug30\t0:00\t@b@f/sbin/mingetty tty1 --noclear");
+
+    win.group().end();
+    win.group().resizable(browser);
+    win.widget().show();
+
     try app.run();
 }

--- a/examples/capi.zig
+++ b/examples/capi.zig
@@ -8,11 +8,10 @@ const c = @cImport({
 });
 
 // fltk initizialization of optional functionalities
-pub fn fltkInit() !void {
+pub fn fltkInit() void {
     c.Fl_init_all(); // inits all styles, if needed
     c.Fl_register_images(); // register image types supported by fltk, if needed
-    const ret = c.Fl_lock(); // enable multithreading, if needed
-    if (ret != 0) unreachable;
+    _ = c.Fl_lock(); // enable multithreading, if needed
 }
 
 // Button callback
@@ -22,7 +21,8 @@ pub fn butCb(w: ?*c.Fl_Widget, data: ?*anyopaque) callconv(.C) void {
 }
 
 pub fn main() !void {
-    try fltkInit();
+    fltkInit();
+
     _ = c.Fl_set_scheme("gtk+");
     var win = c.Fl_Window_new(100, 100, 400, 300, "Hello");
     var but = c.Fl_Button_new(160, 220, 80, 40, "Click me!");

--- a/examples/channels.zig
+++ b/examples/channels.zig
@@ -1,32 +1,67 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
-const widget = zfltk.widget;
-const window = zfltk.window;
-const button = zfltk.button;
-const box = zfltk.box;
+const Widget = zfltk.Widget;
+const Window = zfltk.Window;
+const Button = zfltk.Button;
+const Box = zfltk.Box;
 const enums = zfltk.enums;
 
 pub const Message = enum(usize) {
     // Can't begin with Zero!
-    First = 1,
-    Second,
+    first = 1,
+    second,
 };
 
 pub fn main() !void {
     try app.init();
-    app.setScheme(.Gtk);
-    var win = window.Window.new(100, 100, 400, 300, "Hello");
-    var but1 = button.Button.new(100, 220, 80, 40, "Button 1");
-    var but2 = button.Button.new(200, 220, 80, 40, "Button 2");
-    var mybox = box.Box.new(10, 10, 380, 180, "");
-    win.asGroup().end();
-    win.asWidget().show();
-    but1.asWidget().emit(Message, .First);
-    but2.asWidget().emit(Message, .Second);
+    app.setScheme(.gtk);
+
+    var win = try Window.init(.{
+        .w = 400,
+        .h = 300,
+
+        .label = "Hello",
+    });
+
+    var but1 = try Button(.normal).init(.{
+        .x = 100,
+        .y = 220,
+        .w = 80,
+        .h = 40,
+
+        .label = "Button 1",
+    });
+
+    var but2 = try Button(.normal).init(.{
+        .x = 200,
+        .y = 220,
+        .w = 80,
+        .h = 40,
+
+        .label = "Button 2",
+    });
+
+    var mybox = try Box.init(.{
+        .x = 10,
+        .y = 10,
+        .w = 380,
+        .h = 180,
+
+        .boxtype = .up,
+    });
+
+    mybox.setLabelFont(.courier);
+    mybox.setLabelSize(18);
+
+    win.group().end();
+    win.show();
+    but1.emit(Message, .first);
+    but2.emit(Message, .second);
+
     while (app.wait()) {
         if (app.recv(Message)) |msg| switch (msg) {
-            .First => mybox.asWidget().setLabel("Button 1 Clicked!"),
-            .Second => mybox.asWidget().setLabel("Button 2 Clicked!"),
+            .first => mybox.setLabel("Button 1 Clicked!"),
+            .second => mybox.setLabel("Button 2 Clicked!"),
         };
     }
 }

--- a/examples/customwidget.zig
+++ b/examples/customwidget.zig
@@ -1,0 +1,282 @@
+const zfltk = @import("zfltk");
+const app = zfltk.app;
+const draw = zfltk.draw;
+const Window = zfltk.Window;
+const Widget = zfltk.Widget;
+const Button = zfltk.Button;
+const Box = zfltk.Box;
+const enums = zfltk.enums;
+const Color = enums.Color;
+const Event = enums.Event;
+const Align = enums.Align;
+const std = @import("std");
+
+pub fn main() !void {
+    try app.init();
+    app.setScheme(.oxy);
+
+    app.setVisibleFocus(false);
+
+    var win = try Window.init(.{
+        .w = 400,
+        .h = 284,
+
+        .label = "Custom widget example",
+    });
+
+    var sw1 = try Switch.init(.{
+        .x = 10,
+        .y = 200,
+        .w = 380,
+
+        .label = "Very important feature",
+    });
+
+    var sw2 = try Switch.init(.{
+        .x = 10,
+        .y = 242,
+        .w = 380,
+        .h = 32,
+
+        .label = "Enable animation for the first switch",
+    });
+
+    var box = try Box.init(.{
+        .x = 10,
+        .y = 10,
+        .w = 380,
+        .h = 180,
+
+        .boxtype = .up,
+        .label = "Off",
+    });
+
+    box.widget().setLabelFont(.courier);
+    box.widget().setLabelSize(24);
+
+    sw1.setCallbackEx(switch1Cb, box);
+    sw1.widget().setColor(Color.fromName(.cyan));
+    sw2.setValue(true);
+    sw2.setCallbackEx(switch2Cb, sw1);
+    //_ = sw2;
+
+    win.group().end();
+    win.widget().show();
+
+    try app.run();
+}
+
+fn switch1Cb(sw: *Switch, data: ?*anyopaque) void {
+    var box = Box.fromRaw(data.?);
+
+    const str = if (sw.value()) "On" else "Off";
+    box.widget().setLabel(str);
+}
+
+fn switch2Cb(sw2: *Switch, data: ?*anyopaque) void {
+    var sw1 = Switch.fromVoidPtr(data.?);
+
+    const color = if (sw2.value()) Color.fromName(.cyan) else Color.fromName(.background);
+    sw1.widget().setColor(color);
+    sw1.setAnimation(sw2.value());
+}
+
+const Switch = struct {
+    box1: *Box,
+    box2: *Box,
+    label: *Box,
+    on: bool,
+    opts: Options,
+    animated: bool,
+
+    callback_data: ?*anyopaque,
+    callback: union(enum) {
+        normal: ?*const fn (*Switch) void,
+        extended: ?*const fn (*Switch, ?*anyopaque) void,
+    },
+
+    pub const Options = struct {
+        x: u31 = 0,
+        y: u31 = 0,
+        w: u31 = 64,
+        h: u31 = 32,
+
+        label: ?[:0]const u8 = null,
+    };
+
+    fn drawBox(x1: i32, y1: i32, x2: i32, y2: i32, col: Color) callconv(.C) void {
+        draw.box(.down, x1 + 4, y1 + 4, x2 - 12, y2 - 8, col);
+    }
+
+    fn drawBox2(x1: i32, y1: i32, x2: i32, y2: i32, col: Color) callconv(.C) void {
+        draw.box(.up, x1, y1, x2, y2, col);
+        draw.box(.down, x1 + 4, y1 + 4, x2 - 8, y2 - 8, col);
+    }
+
+    pub fn init(opts: Options) !*Switch {
+        var self = try app.allocator.create(Switch);
+        self.opts = opts;
+        self.animated = true;
+        self.callback = .{ .normal = null };
+
+        app.setBoxTypeEx(.free, drawBox, 4, 4, -8, -8);
+        //app.setBoxTypeEx(.border_frame, drawBox2, 4, 4, -8, -8);
+
+        //        draw.box(.free, 0, 0, self.opts.w, self.opts.h, Color.fromName(.red));
+
+        self.box2 = try Box.init(.{
+            .x = opts.x,
+            .y = opts.y,
+            .w = (opts.h * 2) + 4,
+            .h = opts.h,
+
+            .boxtype = .free,
+        });
+
+        self.box1 = try Box.init(.{
+            .x = opts.x,
+            .y = opts.y,
+            .w = opts.h,
+            .h = opts.h,
+
+            .boxtype = .up,
+        });
+
+        self.label = try Box.init(.{
+            .x = opts.x + (opts.h * 2) + 4,
+            .y = opts.y,
+            .w = opts.w - (opts.h * 2),
+            .h = opts.h,
+
+            .label = opts.label,
+            //.boxtype = .up,
+        });
+
+        self.label.widget().setLabelAlign(Align.left | Align.inside);
+
+        self.box1.setEventHandlerEx(clickEventHandle, self);
+        self.box2.setEventHandlerEx(clickEventHandle, self);
+        self.label.setEventHandlerEx(clickEventHandle, self);
+
+        return self;
+    }
+
+    pub fn deinit(self: *Switch) void {
+        self.box1.deinit();
+        self.box2.deinit();
+        self.label.deinit();
+        app.allocator.destroy(self);
+    }
+
+    fn clickEventHandle(_: *Box, ev: Event, data: ?*anyopaque) bool {
+        var self = Switch.fromVoidPtr(data.?);
+
+        //        var e = self.box1.widget().x();
+        //        self.box1.widget().parent().widget().redraw();
+        //        _ = e;
+        //        self.box1.widget().resize(0, 0, 200, 200);
+
+        switch (ev) {
+            .push => {
+                const h = self.box1.widget().h();
+                const x = if (self.on) self.opts.x + h else self.opts.x;
+                const y = self.box1.widget().y();
+                const w = self.box1.widget().w();
+                //                const w2 = self.options.w;
+
+                const new_x = if (self.on) x - (h) else x + (h);
+
+                self.on = !self.on;
+
+                // Activate callback
+                switch (self.callback) {
+                    .normal => {
+                        if (self.callback.normal) |cb| cb(self);
+                    },
+                    .extended => {
+                        if (self.callback.extended) |cb| cb(self, self.callback_data);
+                    },
+                }
+
+                // Sliding animation
+                if (self.animated) {
+                    if (self.on) {
+                        while (self.box1.widget().x() < new_x) {
+                            var x1 = self.box1.widget().x() +| h / 6;
+                            if (x1 > new_x) x1 = new_x;
+
+                            // One frame at 60fps (what FLTK uses)
+                            std.time.sleep(16_666_666);
+                            self.box1.widget().resize(x1, y, w, h);
+                            self.box1.widget().parent().widget().redraw();
+
+                            _ = app.check();
+
+                            //  draw.box(.down, x, y, w, h, Color.fromName(.background));
+                        }
+                    } else {
+                        while (self.box1.widget().x() > new_x) {
+                            var x1 = self.box1.widget().x() -| h / 6;
+                            if (x1 < new_x) x1 = new_x;
+
+                            std.time.sleep(16_666_666);
+                            self.box1.widget().resize(x1, y, w, h);
+                            self.box1.widget().parent().widget().redraw();
+                            _ = app.check();
+                        }
+                    }
+                } else {
+                    self.box1.widget().resize(new_x, y, w, h);
+                    self.box1.widget().parent().widget().redraw();
+                    _ = app.check();
+                }
+
+                return true;
+            },
+            //     .push => return true,
+            else => return false,
+        }
+
+        return false;
+    }
+
+    pub fn fromVoidPtr(ptr: *anyopaque) *Switch {
+        return @ptrCast(*Switch, @alignCast(@alignOf(Switch), ptr));
+    }
+
+    pub fn widget(self: *Switch) *Widget {
+        //return @ptrCast(*Widget, self);
+        return self.box1.widget();
+    }
+
+    pub fn setCallback(self: *Switch, f: *const fn (*Switch) void) void {
+        self.callback = .{ .normal = f };
+    }
+
+    pub fn setCallbackEx(self: *Switch, f: *const fn (*Switch, ?*anyopaque) void, data: ?*anyopaque) void {
+        self.callback = .{ .extended = f };
+        self.callback_data = data;
+    }
+
+    pub fn value(self: *const Switch) bool {
+        return self.on;
+    }
+
+    pub fn setValue(self: *Switch, val: bool) void {
+        const x = self.box1.widget().x();
+        const y = self.box1.widget().y();
+        const w = self.box1.widget().w();
+        const h = self.box1.widget().h();
+        const new_x = if (self.on) x - (h) else x + (h);
+
+        self.on = val;
+        self.box1.widget().resize(new_x, y, w, h);
+        self.box1.widget().parent().widget().redraw();
+
+        _ = app.check();
+    }
+
+    pub fn setAnimation(self: *Switch, val: bool) void {
+        self.animated = val;
+    }
+};

--- a/examples/editor.zig
+++ b/examples/editor.zig
@@ -1,155 +1,167 @@
+// TODO: This example needs some extra work to properly port to the new API as
+// its a bit larger than other examples but it
+
 const zfltk = @import("zfltk");
 const app = zfltk.app;
 const widget = zfltk.widget;
 const Widget = widget.Widget;
-const window = zfltk.window;
-const menu = zfltk.menu;
+const Window = zfltk.Window;
+const MenuBar = zfltk.MenuBar;
 const enums = zfltk.enums;
 const Color = enums.Color;
-const text = zfltk.text;
+const TextDisplay = zfltk.TextDisplay;
 const dialog = zfltk.dialog;
+const FileDialog = zfltk.FileDialog;
+const std = @import("std");
 
 // To avoid exiting when hitting escape.
 // Also logic can be added to prompt the user to save their work
-pub fn winCb(w: Widget) void {
-    if (app.event() == enums.Event.Close) {
+pub fn winCb(w: *Widget) void {
+    if (app.event() == .close) {
         w.hide();
     }
 }
 
-pub fn newCb(w: Widget, data: ?*anyopaque) void {
-    _ = w;
-    var buf = text.TextBuffer.fromVoidPtr(data);
-    buf.setText("");
+pub fn newCb(_: *Widget, data: ?*anyopaque) void {
+    var editor = TextDisplay(.editor).fromRaw(data.?);
+    editor.buffer().?.setText("");
 }
 
-pub fn openCb(w: Widget, data: ?*anyopaque) void {
-    _ = w;
-    var dlg = dialog.NativeFileDialog.new(.BrowseFile);
+pub fn openCb(_: *Widget, data: ?*anyopaque) void {
+    var editor = TextDisplay(.editor).fromRaw(data.?);
+    var dlg = try FileDialog(.file).init(.{});
     dlg.setFilter("*.{txt,zig}");
     dlg.show();
     var fname = dlg.filename();
-    if (fname != null) {
-        var buf = text.TextBuffer.fromVoidPtr(data);
-        _ = buf.loadFile(fname) catch unreachable;
+    if (!std.mem.eql(u8, fname, "")) {
+        editor.buffer().?.loadFile(fname) catch unreachable;
     }
 }
 
-pub fn saveCb(w: Widget, data: ?*anyopaque) void {
-    _ = w;
-    var dlg = dialog.NativeFileDialog.new(.BrowseSaveFile);
+pub fn saveCb(_: *Widget, data: ?*anyopaque) void {
+    var editor = TextDisplay(.editor).fromRaw(data.?);
+    var dlg = try FileDialog(.file).init(.{});
     dlg.setFilter("*.{txt,zig}");
     dlg.show();
     var fname = dlg.filename();
-    if (fname != null) {
-        var buf = text.TextBuffer.fromVoidPtr(data);
-        _ = buf.saveFile(fname) catch unreachable;
+    if (!std.mem.eql(u8, fname, "")) {
+        editor.buffer().?.loadFile(fname) catch unreachable;
     }
 }
 
-pub fn quitCb(w: Widget, data: ?*anyopaque) void {
+pub fn quitCb(w: *Widget, data: ?*anyopaque) void {
     _ = w;
-    var win = widget.Widget.fromVoidPtr(data);
+    var win = widget.Widget.fromRaw(data.?);
     win.hide();
 }
 
-pub fn cutCb(w: Widget, data: ?*anyopaque) void {
+pub fn cutCb(w: *Widget, data: ?*anyopaque) void {
     _ = w;
-    const editor = text.TextEditor.fromVoidPtr(data);
+    const editor = TextDisplay(.editor).fromRaw(data.?);
     editor.cut();
 }
 
-pub fn copyCb(w: Widget, data: ?*anyopaque) void {
+pub fn copyCb(w: *Widget, data: ?*anyopaque) void {
     _ = w;
-    const editor = text.TextEditor.fromVoidPtr(data);
-    editor.copy();
+    const editor = TextDisplay(.editor).fromRaw(data.?);
+    _ = try editor.buffer().?.copy();
 }
 
-pub fn pasteCb(w: Widget, data: ?*anyopaque) void {
+pub fn pasteCb(w: *Widget, data: ?*anyopaque) void {
     _ = w;
-    const editor = text.TextEditor.fromVoidPtr(data);
+    const editor = TextDisplay(.editor).fromRaw(data.?);
     editor.paste();
 }
 
-pub fn helpCb(w: Widget, data: ?*anyopaque) void {
-    _ = w;
-    _ = data;
+pub fn helpCb(_: *Widget) void {
     dialog.message(300, 200, "This editor was built using fltk and zig!");
 }
 
 pub fn main() !void {
     try app.init();
-    app.setScheme(.Gtk);
+    app.setScheme(.gtk);
     app.setBackground(Color.fromRgb(211, 211, 211));
-    var win = window.Window.new(100, 100, 800, 600, "Editor");
+
+    var win = try Window.init(.{
+        .w = 800,
+        .h = 600,
+
+        .label = "Editor",
+    });
+
     win.freePosition();
-    var mymenu = menu.MenuBar.new(0, 0, 800, 35, "");
-    var buf = text.TextBuffer.new();
-    defer buf.delete();
-    var editor = text.TextEditor.new(2, 37, 800 - 2, 600 - 37, "");
-    editor.asTextDisplay().setBuffer(&buf);
-    editor.asTextDisplay().setLinenumberWidth(24);
-    win.asGroup().end();
-    win.asGroup().add(&editor.asWidget());
-    win.asGroup().resizable(&editor.asWidget());
-    win.asWidget().show();
-    win.asWidget().setCallback(winCb);
+    var mymenu = MenuBar.new(0, 0, 800, 35, "");
+
+    var editor = try TextDisplay(.editor).init(.{
+        .x = 2,
+        .y = 37,
+        .w = 800 - 2,
+        .h = 600 - 37,
+    });
+
+    editor.setLinenumberWidth(24);
+    win.group().end();
+
+    win.group().add(.{editor});
+    win.group().resizable(editor);
+
+    win.widget().show();
+    win.widget().setCallback(winCb);
 
     mymenu.asMenu().addEx(
         "&File/New...\t",
         enums.Shortcut.Ctrl | 'n',
         .Normal,
         newCb,
-        buf.toVoidPtr(),
+        editor,
     );
     mymenu.asMenu().addEx(
         "&File/Open...\t",
         enums.Shortcut.Ctrl | 'o',
         .Normal,
         openCb,
-        buf.toVoidPtr(),
+        editor,
     );
     mymenu.asMenu().addEx(
         "&File/Save...\t",
         enums.Shortcut.Ctrl | 's',
         .MenuDivider,
         saveCb,
-        buf.toVoidPtr(),
+        editor,
     );
     mymenu.asMenu().addEx(
         "&File/Quit...\t",
         enums.Shortcut.Ctrl | 'q',
         .Normal,
         quitCb,
-        win.toVoidPtr(),
+        win,
     );
     mymenu.asMenu().addEx(
         "&Edit/Cut...\t",
         enums.Shortcut.Ctrl | 'x',
         .Normal,
         cutCb,
-        editor.toVoidPtr(),
+        editor,
     );
     mymenu.asMenu().addEx(
         "&Edit/Copy...\t",
         enums.Shortcut.Ctrl | 'c',
         .Normal,
         copyCb,
-        editor.toVoidPtr(),
+        editor,
     );
     mymenu.asMenu().addEx(
         "&Edit/Paste...\t",
         enums.Shortcut.Ctrl | 'v',
         .Normal,
         pasteCb,
-        editor.toVoidPtr(),
+        editor,
     );
-    mymenu.asMenu().addEx(
+    mymenu.asMenu().add(
         "&Help/About...\t",
         enums.Shortcut.Ctrl | 'q',
         .Normal,
         helpCb,
-        null,
     );
 
     var item = mymenu.asMenu().findItem("&File/Quit...\t");

--- a/examples/editormsgs.zig
+++ b/examples/editormsgs.zig
@@ -25,16 +25,17 @@ pub const Message = enum(usize) {
 // Also logic can be added to prompt the user to save their work
 pub fn winCb(w: Widget) void {
     _ = w;
-    if (app.event() == enums.Event.Close) {
+    if (app.event() == .close) {
         app.send(Message, .Quit);
     }
 }
 
 pub fn main() !void {
     try app.init();
-    app.setScheme(.Gtk);
+    app.setScheme(.gtk);
+
     app.setBackground(Color.fromRgb(211, 211, 211));
-    var win = window.Window.new(0, 0, 800, 600, "Editor");
+    var win = window.Window.init(0, 0, 800, 600, "Editor");
     win.freePosition();
     var mymenu = menu.MenuBar.new(0, 0, 800, 35, "");
     var buf = text.TextBuffer.new();
@@ -42,9 +43,9 @@ pub fn main() !void {
     var editor = text.TextEditor.new(2, 37, 800 - 2, 600 - 37, "");
     editor.asTextDisplay().setBuffer(&buf);
     editor.asTextDisplay().setLinenumberWidth(24);
-    win.asGroup().end();
-    win.asWidget().show();
-    win.asWidget().setCallback(winCb);
+    win.group().end();
+    win.widget().show();
+    win.widget().setCallback(winCb);
 
     mymenu.asMenu().addEmit(
         "&File/New...\t",
@@ -127,7 +128,7 @@ pub fn main() !void {
                     _ = buf.saveFile(fname) catch unreachable;
                 }
             },
-            .Quit => win.asWidget().hide(),
+            .Quit => win.widget().hide(),
             .Cut => editor.cut(),
             .Copy => editor.copy(),
             .Paste => editor.paste(),

--- a/examples/flex.zig
+++ b/examples/flex.zig
@@ -1,24 +1,54 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
-const widget = zfltk.widget;
-const window = zfltk.window;
-const box = zfltk.box;
-const button = zfltk.button;
-const group = zfltk.group;
+const Window = zfltk.Window;
+const Box = zfltk.Box;
+const Button = zfltk.Button;
+const Group = zfltk.Group;
+const Color = enums.Color;
 const enums = zfltk.enums;
 
 pub fn main() !void {
     try app.init();
-    var win = window.Window.new(100, 100, 400, 300, "Hello");
-    var flex = group.Flex.new(0, 0, 400, 300, "");
-    flex.asWidget().setType(group.FlexType, .Vertical);
-    flex.setPad(5);
-    _ = box.Box.new(0, 0, 0, 0, null);
-    var btn = button.Button.new(0, 0, 0, 0, "Button");
-    _ = box.Box.new(0, 0, 0, 0, null);
-    flex.fixed(&btn.asWidget(), 30);
-    flex.end(); // flex has its own end method which recalculates layouts
-    win.asGroup().end();
-    win.asWidget().show();
+
+    var win = try Window.init(.{
+        .w = 400,
+        .h = 300,
+
+        .label = "Hello",
+    });
+
+    var flex = try Group(.flex).init(.{
+        .w = 400,
+        .h = 300,
+
+        // The orientation is vertical by default so this isn't necessary to
+        // set; this is just for reference
+        .orientation = .vertical,
+        .spacing = 6,
+    });
+
+    win.group().resizable(flex);
+
+    var btn = try Button(.normal).init(.{
+        .h = 48,
+        .label = "Button",
+    });
+
+    // This demonstrates how you can add inline widgets which have no purpose
+    // besides aesthetics. This could be useful for spacers and whatnot
+    flex.add(.{
+        try Box.init(.{ .boxtype = .down }),
+        btn,
+        try Box.init(.{ .boxtype = .down }),
+    });
+
+    flex.fixed(btn, btn.h());
+
+    // Flex has its own `end` method which recalculates layouts but the API
+    // remains consistent by utilizing Zig's comptime
+    flex.end();
+
+    win.group().end();
+    win.widget().show();
     try app.run();
 }

--- a/examples/image.zig
+++ b/examples/image.zig
@@ -1,18 +1,46 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
-const widget = zfltk.widget;
-const image = zfltk.image;
-const window = zfltk.window;
-const box = zfltk.box;
+const SharedImage = zfltk.image.SharedImage;
+const Image = zfltk.Image;
+const Window = zfltk.Window;
+const Box = zfltk.Box;
+const Group = zfltk.Group;
+const Align = zfltk.enums.Align;
+const std = @import("std");
 
 pub fn main() !void {
     try app.init();
-    var win = window.Window.new(100, 100, 400, 300, "Image");
-    var mybox = box.Box.new(0, 0, 400, 300, "");
-    win.asGroup().end();
-    win.asWidget().show();
-    var img = try image.SharedImage.load("screenshots/logo.png");
-    img.asImage().scale(400, 300, false, true);
-    mybox.asWidget().setImage(img.asImage());
+
+    var win = try Window.init(.{
+        .w = 415,
+        .h = 140,
+
+        .label = "Image demo",
+    });
+
+    var scroll = try Group(.scroll).init(.{
+        .w = 415,
+        .h = 140,
+    });
+
+    scroll.setScrollBar(.vertical);
+
+    var mybox = try Box.init(.{
+        .w = 400,
+        .h = 280,
+
+        .boxtype = .up,
+    });
+
+    scroll.add(.{mybox});
+    win.group().add(.{scroll});
+
+    var img = try Image.load(.png, "screenshots/logo.png");
+
+    mybox.widget().setImage(img);
+
+    win.group().end();
+    win.show();
+
     try app.run();
 }

--- a/examples/layout.zig
+++ b/examples/layout.zig
@@ -1,26 +1,52 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
-const widget = zfltk.widget;
-const window = zfltk.window;
-const button = zfltk.button;
-const group = zfltk.group;
+const Window = zfltk.Window;
+const Box = zfltk.Box;
+const Button = zfltk.Button;
+const Group = zfltk.Group;
+const Color = enums.Color;
 const enums = zfltk.enums;
 
 pub fn main() !void {
     try app.init();
-    app.setScheme(.Gtk);
-    var win = window.Window.new(100, 100, 400, 300, "Hello");
-    var pack = group.Pack.new(0, 0, 400, 300, "");
-    pack.asWidget().setType(group.PackType, .Vertical);
-    pack.setSpacing(40);
-    @import("std").debug.print("{}\n", .{pack.spacing()});
-    _ = button.Button.new(0, 0, 0, 40, "Button 1");
-    _ = button.Button.new(0, 0, 0, 40, "Button 2");
-    _ = button.Button.new(0, 0, 0, 40, "Button 3");
-    win.asGroup().add(&pack.asWidget());
-    win.asGroup().resizable(&pack.asWidget());
-    pack.asGroup().end();
-    win.asGroup().end();
-    win.asWidget().show();
+
+    var win = try Window.init(.{
+        .w = 400,
+        .h = 300,
+
+        .label = "Hello",
+    });
+
+    var pack = try Group(.pack).init(.{
+        .w = 400,
+        .h = 300,
+
+        // The orientation is vertical by default so this isn't necessary to
+        // set; this is just for reference
+        .orientation = .vertical,
+        .spacing = 6,
+    });
+
+    win.group().resizable(pack);
+
+    var btn = try Button(.normal).init(.{
+        .h = 48,
+        .label = "Button",
+    });
+
+    // In pack groups, the size must be provided as they don't automatically
+    // adjust like flex groups. See `flex.zig`
+    pack.add(.{
+        try Box.init(.{ .h = 48, .boxtype = .down }),
+        btn,
+        try Box.init(.{ .h = 48, .boxtype = .down }),
+    });
+
+    // Flex has its own `end` method which recalculates layouts but the API
+    // remains consistent by utilizing Zig's comptime
+    pack.end();
+
+    win.group().end();
+    win.widget().show();
     try app.run();
 }

--- a/examples/simple.zig
+++ b/examples/simple.zig
@@ -1,34 +1,53 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
-const widget = zfltk.widget;
-const Widget = widget.Widget;
-const window = zfltk.window;
-const button = zfltk.button;
-const box = zfltk.box;
+const Window = zfltk.Window;
+const Button = zfltk.Button;
+const Box = zfltk.Box;
 const Color = zfltk.enums.Color;
 
-pub fn butCb(w: Widget, data: ?*anyopaque) void {
-    var mybox = widget.Widget.fromVoidPtr(data);
-    mybox.setLabel("Hello World!");
+fn butCb(but: *Button(.normal), data: ?*anyopaque) void {
+    var box = Box.fromRaw(data.?);
 
-    var but = button.Button.fromWidgetPtr(w.inner); // You can still use a Widget.fromWidgetPtr
-    but.asWidget().setColor(Color.fromName(.cyan));
+    box.setLabel("Hello World!");
+
+    but.setColor(Color.fromName(.cyan));
 }
 
 pub fn main() !void {
     try app.init();
-    app.setScheme(.Gtk);
+    app.setScheme(.gtk);
 
-    var win = window.Window.new(100, 100, 400, 300, "Hello");
-    var but = button.Button.new(160, 220, 80, 40, "Click");
-    var mybox = box.Box.new(10, 10, 380, 180, "");
+    var win = try Window.init(.{
+        .w = 400,
+        .h = 300,
 
-    mybox.asWidget().setBox(.UpBox);
-    mybox.asWidget().setLabelFont(.Courier);
-    mybox.asWidget().setLabelSize(18);
+        .label = "Hello",
+    });
 
-    win.asGroup().end();
-    win.asWidget().show();
-    but.asWidget().setCallbackEx(butCb, mybox.toVoidPtr());
+    var but = try Button(.normal).init(.{
+        .x = 160,
+        .y = 220,
+        .w = 80,
+        .h = 40,
+
+        .label = "Click me!",
+    });
+
+    var box = try Box.init(.{
+        .x = 10,
+        .y = 10,
+        .w = 380,
+        .h = 180,
+
+        .boxtype = .up,
+    });
+
+    box.setLabelFont(.courier);
+    box.setLabelSize(18);
+
+    win.group().end();
+    win.widget().show();
+
+    but.setCallbackEx(butCb, box);
     try app.run();
 }

--- a/examples/valuators.zig
+++ b/examples/valuators.zig
@@ -1,27 +1,59 @@
 const zfltk = @import("zfltk");
 const app = zfltk.app;
-const widget = zfltk.widget;
-const window = zfltk.window;
+const Widget = zfltk.Widget;
+const Window = zfltk.Window;
 const valuator = zfltk.valuator;
-const group = zfltk.group;
+const Group = zfltk.Group;
 const enums = zfltk.enums;
+const Valuator = zfltk.Valuator;
 
 pub fn main() !void {
     try app.init();
-    app.setScheme(.Gtk);
-    var win = window.Window.new(100, 100, 400, 300, "Hello");
-    var pack = group.Pack.new(0, 0, 400, 300, "");
-    pack.asWidget().setType(group.PackType, .Vertical);
-    pack.setSpacing(40);
-    var slider = valuator.Slider.new(0, 0, 0, 40, "Slider");
-    slider.asWidget().setType(valuator.SliderType, .HorizontalNice);
-    const scrollbar = valuator.Scrollbar.new(0, 0, 0, 40, "Scrollbar");
-    scrollbar.asWidget().setType(valuator.ScrollbarType, .HorizontalNice);
-    _ = valuator.Counter.new(0, 0, 0, 40, "Counter");
-    _ = valuator.Adjuster.new(0, 0, 0, 40, "Adjuster");
-    pack.asGroup().end();
-    win.asGroup().end();
-    win.asWidget().show();
+    app.setScheme(.gtk);
+
+    var win = try Window.init(.{
+        .w = 400,
+        .h = 300,
+
+        .label = "Valuators",
+    });
+
+    var pack = try Group(.pack).init(.{
+        .w = 400,
+        .h = 300,
+
+        .spacing = 40,
+    });
+
+    pack.add(.{
+        try Valuator(.slider).init(.{
+            .h = 40,
+            .style = .nice,
+            .orientation = .horizontal,
+            .label = "Slider",
+        }),
+
+        try Valuator(.scrollbar).init(.{
+            .h = 40,
+            .style = .nice,
+            .orientation = .horizontal,
+            .label = "Scrollbar",
+        }),
+
+        try Valuator(.counter).init(.{
+            .h = 40,
+            .w = win.w(),
+            .label = "Counter",
+        }),
+
+        try Valuator(.adjuster).init(.{
+            .h = 40,
+            .label = "Adjuster",
+        }),
+    });
+
+    pack.end();
+    win.end();
+    win.show();
     try app.run();
 }
-

--- a/src/box.zig
+++ b/src/box.zig
@@ -1,37 +1,49 @@
-const c = @cImport({
-    @cInclude("cfl_box.h");
-});
-const widget = @import("widget.zig");
+const zfltk = @import("zfltk.zig");
+const app = zfltk.app;
+const std = @import("std");
+const Widget = @import("widget.zig").Widget;
+const Event = @import("enums.zig").Event;
+const enums = zfltk.enums;
+const c = zfltk.c;
 
 pub const Box = struct {
-    inner: ?*c.Fl_Box,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Box {
-        const ptr = c.Fl_Box_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Box{
-            .inner = ptr,
-        };
+    const Self = @This();
+
+    pub usingnamespace zfltk.widget.methods(Self, *c.Fl_Box);
+
+    pub const Options = struct {
+        x: u31 = 0,
+        y: u31 = 0,
+        w: u31 = 0,
+        h: u31 = 0,
+
+        label: ?[:0]const u8 = null,
+
+        boxtype: enums.BoxType = .none,
+    };
+
+    pub inline fn init(opts: Options) !*Self {
+        const label = if (opts.label != null) opts.label.?.ptr else null;
+
+        if (c.Fl_Box_new(opts.x, opts.y, opts.w, opts.h, label)) |ptr| {
+            if (opts.boxtype != .none) {
+                c.Fl_Widget_set_box(@ptrCast(*c.Fl_Widget, ptr), @enumToInt(opts.boxtype));
+            }
+
+            return @ptrCast(*Self, ptr);
+        }
+
+        unreachable;
     }
 
-    pub fn raw(self: *const Box) ?*c.Fl_Box {
-        return self.inner;
+    pub inline fn deinit(self: *Self) void {
+        c.Fl_Box_delete(self.inner);
+        app.allocator.destroy(self);
     }
 
-    pub fn fromRaw(ptr: ?*c.Fl_Box) Box {
-        return Box{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Box {
-        return Box{
-            .inner = @ptrCast(?*c.Fl_Box, w),
-        };
-    }
-
-    pub fn fromDynWidgetPtr(w: widget.WidgetPtr) ?Box {
-        if (c.Fl_Box_from_dyn_ptr(@ptrCast(?*c.Fl_Widget, w))) |v| {
-            return Box{
+    pub inline fn fromDynWidgetPtr(w: *c.Fl_Widget) ?Self {
+        if (c.Fl_Box_from_dyn_ptr(@ptrCast(Widget.RawPoiner, w))) |v| {
+            return .{
                 .inner = v,
             };
         } else {
@@ -39,30 +51,59 @@ pub const Box = struct {
         }
     }
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Box {
-        return Box{
-            .inner = @ptrCast(?*c.Fl_Box, ptr),
-        };
+    pub inline fn setEventHandler(self: *const Self, f: *const fn (*Self, Event) bool) void {
+        c.Fl_Box_handle(
+            self.raw(),
+            zfltk_box_event_handler,
+            @intToPtr(*anyopaque, @ptrToInt(&f)),
+        );
     }
 
-    pub fn toVoidPtr(self: *const Box) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
+    pub inline fn setEventHandlerEx(self: *Self, f: *const fn (*Self, Event, ?*anyopaque) bool, data: ?*anyopaque) void {
+        var container = app.allocator.alloc(usize, 2) catch unreachable;
+
+        container[0] = @ptrToInt(f);
+        container[1] = @ptrToInt(data);
+
+        c.Fl_Box_handle(
+            self.raw(),
+            zfltk_box_event_handler_ex,
+            @ptrCast(*anyopaque, container.ptr),
+        );
     }
 
-    pub fn asWidget(self: *const Box) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Box, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Box_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Box, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Box_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
+    // TODO: refactor this to match `setHandle` for memory safety
+    pub fn draw(self: *const Self, cb: fn (w: *c.Fl_Widget, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+        c.Fl_Box_handle(self.raw(), @ptrCast(c.custom_draw_callback, cb), data);
     }
 };
+
+export fn zfltk_box_event_handler(wid: ?*c.Fl_Widget, ev: c_int, data: ?*anyopaque) callconv(.C) c_int {
+    const cb = @ptrCast(
+        *const fn (*Widget, Event) bool,
+        data,
+    );
+
+    return @boolToInt(cb(
+        Widget.fromRaw(wid.?),
+        @intToEnum(Event, ev),
+    ));
+}
+
+export fn zfltk_box_event_handler_ex(wid: ?*c.Fl_Widget, ev: c_int, data: ?*anyopaque) callconv(.C) c_int {
+    const container = @ptrCast(*[2]usize, @alignCast(@alignOf(usize), data));
+
+    const cb = @intToPtr(
+        *const fn (*Widget, Event, ?*anyopaque) bool,
+        container[0],
+    );
+
+    return @boolToInt(cb(
+        Widget.fromRaw(wid.?),
+        @intToEnum(Event, ev),
+        @intToPtr(?*anyopaque, container[1]),
+    ));
+}
 
 test "all" {
     @import("std").testing.refAllDecls(@This());

--- a/src/browser.zig
+++ b/src/browser.zig
@@ -1,431 +1,244 @@
-const c = @cImport({
-    @cInclude("cfl_browser.h");
-});
-const widget = @import("widget.zig");
-const valuator = @import("valuator.zig");
+const zfltk = @import("zfltk.zig");
+const app = zfltk.app;
+const Widget = @import("widget.zig").Widget;
+const Valuator = @import("valuator.zig").Valuator;
 const enums = @import("enums.zig");
+const c = zfltk.c;
 
-pub const Browser = struct {
-    inner: ?*c.Fl_Browser,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Browser {
-        const ptr = c.Fl_Browser_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Browser{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Browser) ?*c.Fl_Browser {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Browser) Browser {
-        return Browser{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Browser {
-        return Browser{
-            .inner = @ptrCast(?*c.Fl_Browser, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Browser {
-        return Browser{
-            .inner = @ptrCast(?*c.Fl_Browser, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Browser) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Browser) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Browser, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Browser_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Browser, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Browser_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-
-    pub fn remove(self: *const Browser, line: u32) void {
-        return c.Fl_Browser_remove(self.inner, line);
-    }
-
-    pub fn add(self: *const Browser, item: [*c]const u8) void {
-        return c.Fl_Browser_add(self.inner, item);
-    }
-
-    pub fn insert(self: *const Browser, line: u32, item: [*c]const u8) void {
-        return c.Fl_Browser_insert(self.inner, line, item);
-    }
-    pub fn moveItem(self: *const Browser, to: u32, from: u32) void {
-        return c.Fl_Browser_move_item(self.inner, to, from);
-    }
-
-    pub fn swap(self: *const Browser, a: u32, b: u32) void {
-        return c.Fl_Browser_swap(self.inner, a, b);
-    }
-
-    pub fn clear(self: *const Browser) void {
-        return c.Fl_Browser_clear(self.inner);
-    }
-
-    pub fn size(self: *const Browser) u32 {
-        return c.Fl_Browser_size(self.inner);
-    }
-
-    pub fn setSize(self: *const Browser, w: i32, h: i32) void {
-        return c.Fl_Browser_set_size(self.inner, w, h);
-    }
-
-    pub fn select(self: *const Browser, line: u32) void {
-        if (line <= self.size()) return c.Fl_Browser_select(self.inner, line);
-    }
-
-    pub fn selected(self: *const Browser, line: u32) bool {
-        return c.Fl_Browser_selected(self.inner, line) != 0;
-    }
-
-    pub fn text(self: *const Browser, line: u32) [*c]const u8 {
-        return c.Fl_Browser_text(self.inner, line);
-    }
-
-    pub fn setText(self: *const Browser, line: u32, txt: [*c]const u8) void {
-        return c.Fl_Browser_set_text(self.inner, line, txt);
-    }
-
-    pub fn load(self: *const Browser, path: [*c]const u8) void {
-        return c.Fl_Browser_load_file(self.inner, path);
-    }
-
-    pub fn textSize(self: *const Browser) u32 {
-        return c.Fl_Browser_text_size(self.inner);
-    }
-
-    pub fn setTextSize(self: *const Browser, val: u32) void {
-        return c.Fl_Browser_set_text_size(self.inner, val);
-    }
-
-    pub fn topline(self: *const Browser, line: u32) void {
-        return c.Fl_Browser_topline(self.inner, line);
-    }
-
-    pub fn bottomline(self: *const Browser, line: u32) void {
-        return c.Fl_Browser_bottomline(self.inner, line);
-    }
-
-    pub fn middleline(self: *const Browser, line: u32) void {
-        return c.Fl_Browser_middleline(self.inner, line);
-    }
-
-    pub fn formatChar(self: *const Browser) u8 {
-        return c.Fl_Browser_format_char(self.inner);
-    }
-
-    pub fn setFormatChar(self: *const Browser, char: u8) void {
-        return c.Fl_Browser_set_format_char(self.inner, char);
-    }
-
-    pub fn columnChar(self: *const Browser) u8 {
-        return c.Fl_Browser_column_char(self.inner);
-    }
-
-    pub fn setColumnChar(self: *const Browser, char: u8) void {
-        return c.Fl_Browser_set_column_char(self.inner, char);
-    }
-
-    pub fn setColumnWidths(self: *const Browser, arr: [*:0]const i32) void {
-        return c.Fl_Browser_set_column_widths(self.inner, arr);
-    }
-
-    pub fn displayed(self: *const Browser, line: u32) bool {
-        return c.Fl_Browser_displayed(self.inner, line) != 0;
-    }
-
-    pub fn makeVisible(self: *const Browser, line: u32) void {
-        return c.Fl_Browser_make_visible(self.inner, line);
-    }
-
-    pub fn position(self: *const Browser) u32 {
-        return c.Fl_Browser_position(self.inner);
-    }
-
-    pub fn setPosition(self: *const Browser, pos: u32) void {
-        return c.Fl_Browser_set_position(self.inner, pos);
-    }
-
-    pub fn hposition(self: *const Browser) u32 {
-        return c.Fl_Browser_hposition(self.inner);
-    }
-
-    pub fn setHposition(self: *const Browser, pos: u32) void {
-        return c.Fl_Browser_set_hposition(self.inner, pos);
-    }
-
-    pub fn hasScrollbar(self: *const Browser) enums.BrowserScrollbar {
-        return c.Fl_Browser_has_scrollbar(self.inner);
-    }
-
-    pub fn setHasScrollbar(self: *const Browser, mode: enums.BrowserScrollbar) void {
-        return c.Fl_Browser_set_has_scrollbar(self.inner, mode);
-    }
-
-    pub fn scrollbarSize(self: *const Browser) u32 {
-        return c.Fl_Browser_scrollbar_size(self.inner);
-    }
-
-    pub fn setScrollbarSize(self: *const Browser, new_size: u32) void {
-        return c.Fl_Browser_set_scrollbar_size(self.inner, new_size);
-    }
-
-    pub fn sort(self: *const Browser) void {
-        return c.Fl_Browser_sort(self.inner);
-    }
-
-    pub fn scrollbar(self: *const Browser) valuator.Valuator {
-        return valuator.Valuator{ .inner = c.Fl_Browser_scrollbar(self.inner) };
-    }
-
-    pub fn hscrollbar(self: *const Browser) valuator.Valuator {
-        return valuator.Valuator{ .inner = c.Fl_Browser_hscrollbar(self.inner) };
-    }
+pub const BrowserKind = enum {
+    normal,
+    select,
+    hold,
+    multi,
+    file,
 };
 
-pub const SelectBrowser = struct {
-    inner: ?*c.Fl_Select_Browser,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) SelectBrowser {
-        const ptr = c.Fl_Select_Browser_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return SelectBrowser{
-            .inner = ptr,
+pub fn Browser(comptime kind: BrowserKind) type {
+    return struct {
+        const Self = @This();
+
+        const BrowserRawPtr = *c.Fl_Browser;
+
+        pub const RawPtr = switch (kind) {
+            .normal => *c.Fl_Browser,
+            .select => *c.Fl_Select_Browser,
+            .hold => *c.Fl_Hold_Browser,
+            .multi => *c.Fl_Multi_Browser,
+            .file => *c.Fl_File_Browser,
         };
-    }
 
-    pub fn raw(self: *const SelectBrowser) ?*c.Fl_Select_Browser {
-        return self.inner;
-    }
+        inner: RawPtr,
 
-    pub fn fromRaw(ptr: ?*c.Fl_Select_Browser) SelectBrowser {
-        return SelectBrowser{
-            .inner = ptr,
-        };
-    }
+        pub inline fn init(opts: Widget.Options) !*Self {
+            const init_func = switch (kind) {
+                .normal => c.Fl_Browser_new,
+                .select => c.Fl_Select_Browser_new,
+                .hold => c.Fl_Hold_Browser_new,
+                .multi => c.Fl_Multi_Browser_new,
+                .file => c.Fl_File_Browser_new,
+            };
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) SelectBrowser {
-        return SelectBrowser{
-            .inner = @ptrCast(?*c.Fl_Select_Browser, w),
-        };
-    }
+            const label = if (opts.label != null) opts.label.?.ptr else null;
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) SelectBrowser {
-        return SelectBrowser{
-            .inner = @ptrCast(?*c.Fl_Select_Browser, ptr),
-        };
-    }
+            if (init_func(opts.x, opts.y, opts.w, opts.h, label)) |ptr| {
+                var self = try app.allocator.create(Self);
+                self.inner = ptr;
 
-    pub fn toVoidPtr(self: *const SelectBrowser) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
+                return self;
+            }
 
-    pub fn asWidget(self: *const SelectBrowser) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
+            unreachable;
+        }
 
-    pub fn asBrowser(self: *const SelectBrowser) Browser {
-        return Browser{
-            .inner = @ptrCast(?*c.Fl_Browser, self.inner),
-        };
-    }
+        pub inline fn deinit(self: *Self) void {
+            const deinit_func = switch (kind) {
+                .normal => c.Fl_Browser_delete,
+                .select => c.Fl_Select_Browser_delete,
+                .hold => c.Fl_Hold_Browser_delete,
+                .multi => c.Fl_Multi_Browser_delete,
+                .file => c.Fl_File_Browser_delete,
+            };
 
-    pub fn handle(self: *const SelectBrowser, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Select_Browser_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
+            deinit_func(self.inner);
+        }
 
-    pub fn draw(self: *const SelectBrowser, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Select_Browser_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
+        pub inline fn raw(self: *const Self) RawPtr {
+            return self.inner;
+        }
 
-pub const HoldBrowser = struct {
-    inner: ?*c.Fl_Hold_Browser,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) HoldBrowser {
-        const ptr = c.Fl_Hold_Browser_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return HoldBrowser{
-            .inner = ptr,
-        };
-    }
+        pub inline fn fromRaw(ptr: RawPtr) Self {
+            return .{ .inner = ptr };
+        }
 
-    pub fn raw(self: *const HoldBrowser) ?*c.Fl_Hold_Browser {
-        return self.inner;
-    }
+        pub inline fn fromWidget(wid: Widget) Self {
+            return Self.fromRaw(@ptrCast(RawPtr, wid.inner));
+        }
 
-    pub fn fromRaw(ptr: ?*c.Fl_Hold_Browser) HoldBrowser {
-        return HoldBrowser{
-            .inner = ptr,
-        };
-    }
+        pub inline fn fromVoidPtr(ptr: *anyopaque) Self {
+            return .{ .inner = @ptrCast(RawPtr, ptr) };
+        }
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) HoldBrowser {
-        return HoldBrowser{
-            .inner = @ptrCast(?*c.Fl_Hold_Browser, w),
-        };
-    }
+        pub inline fn toVoidPtr(self: *const Self) *anyopaque {
+            return @ptrCast(*anyopaque, self.inner);
+        }
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) HoldBrowser {
-        return HoldBrowser{
-            .inner = @ptrCast(?*c.Fl_Hold_Browser, ptr),
-        };
-    }
+        pub inline fn widget(self: *const Self) Widget {
+            return Widget.fromRaw(@ptrCast(Widget.RawPtr, self.inner));
+        }
 
-    pub fn toVoidPtr(self: *const HoldBrowser) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
+        pub fn handle(self: *const Self, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
+            c.Fl_Browser_handle(self.browser(), @ptrCast(c.custom_handler_callback, cb), data);
+        }
 
-    pub fn asWidget(self: *const HoldBrowser) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
+        pub fn draw(self: *const Self, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+            c.Fl_Browser_handle(@ptrCast(BrowserRawPtr, self.inner), @ptrCast(c.custom_draw_callback, cb), data);
+        }
 
-    pub fn asBrowser(self: *const HoldBrowser) Browser {
-        return Browser{
-            .inner = @ptrCast(?*c.Fl_Browser, self.inner),
-        };
-    }
+        pub fn remove(self: *const Self, line: u32) void {
+            return c.Fl_Browser_remove(@ptrCast(BrowserRawPtr, self.inner), line);
+        }
 
-    pub fn handle(self: *const HoldBrowser, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Hold_Browser_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
+        pub fn add(self: *const Self, item: [:0]const u8) void {
+            return c.Fl_Browser_add(@ptrCast(BrowserRawPtr, self.inner), item.ptr);
+        }
 
-    pub fn draw(self: *const HoldBrowser, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Hold_Browser_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
+        pub fn insert(self: *const Self, line: u32, item: [:0]const u8) void {
+            return c.Fl_Browser_insert(@ptrCast(BrowserRawPtr, self.inner), line, item.ptr);
+        }
 
-pub const MultiBrowser = struct {
-    inner: ?*c.Fl_Multi_Browser,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) MultiBrowser {
-        const ptr = c.Fl_Multi_Browser_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return MultiBrowser{
-            .inner = ptr,
-        };
-    }
+        pub fn moveItem(self: *const Self, to: u32, from: u32) void {
+            return c.Fl_Browser_move_item(@ptrCast(BrowserRawPtr, self.inner), to, from);
+        }
 
-    pub fn raw(self: *const MultiBrowser) ?*c.Fl_Multi_Browser {
-        return self.inner;
-    }
+        pub fn swap(self: *const Self, a: u32, b: u32) void {
+            return c.Fl_Browser_swap(@ptrCast(BrowserRawPtr, self.inner), a, b);
+        }
 
-    pub fn fromRaw(ptr: ?*c.Fl_Multi_Browser) MultiBrowser {
-        return MultiBrowser{
-            .inner = ptr,
-        };
-    }
+        pub fn clear(self: *const Self) void {
+            return c.Fl_Browser_clear(@ptrCast(BrowserRawPtr, self.inner));
+        }
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) MultiBrowser {
-        return MultiBrowser{
-            .inner = @ptrCast(?*c.Fl_Multi_Browser, w),
-        };
-    }
+        pub fn size(self: *const Self) u32 {
+            return c.Fl_Browser_size(@ptrCast(BrowserRawPtr, self.inner));
+        }
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) MultiBrowser {
-        return MultiBrowser{
-            .inner = @ptrCast(?*c.Fl_Multi_Browser, ptr),
-        };
-    }
+        pub fn setSize(self: *const Self, w: i32, h: i32) void {
+            return c.Fl_Browser_set_size(@ptrCast(BrowserRawPtr, self.inner), w, h);
+        }
 
-    pub fn toVoidPtr(self: *const MultiBrowser) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
+        pub fn select(self: *const Self, line: u32) void {
+            if (line <= self.size()) return c.Fl_Browser_select(@ptrCast(BrowserRawPtr, self.inner), line);
+        }
 
-    pub fn asWidget(self: *const MultiBrowser) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
+        pub fn selected(self: *const Self, line: u32) bool {
+            return c.Fl_Browser_selected(@ptrCast(BrowserRawPtr, self.inner), line) != 0;
+        }
 
-    pub fn asBrowser(self: *const MultiBrowser) Browser {
-        return Browser{
-            .inner = @ptrCast(?*c.Fl_Browser, self.inner),
-        };
-    }
+        pub fn text(self: *const Self, line: u32) [:0]const u8 {
+            return c.Fl_Browser_text(@ptrCast(BrowserRawPtr, self.inner), line);
+        }
 
-    pub fn handle(self: *const MultiBrowser, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Multi_Browser_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
+        pub fn setText(self: *const Self, line: u32, txt: [*c]const u8) void {
+            return c.Fl_Browser_set_text(@ptrCast(BrowserRawPtr, self.inner), line, txt);
+        }
 
-    pub fn draw(self: *const MultiBrowser, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Multi_Browser_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
+        pub fn load(self: *const Self, path: [*c]const u8) void {
+            return c.Fl_Browser_load_file(@ptrCast(BrowserRawPtr, self.inner), path);
+        }
 
-pub const FileBrowser = struct {
-    inner: ?*c.Fl_File_Browser,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) FileBrowser {
-        const ptr = c.Fl_File_Browser_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return FileBrowser{
-            .inner = ptr,
-        };
-    }
+        pub fn textSize(self: *const Self) u32 {
+            return c.Fl_Browser_text_size(@ptrCast(BrowserRawPtr, self.inner));
+        }
 
-    pub fn raw(self: *const FileBrowser) ?*c.Fl_File_Browser {
-        return self.inner;
-    }
+        pub fn setTextSize(self: *const Self, val: u32) void {
+            return c.Fl_Browser_set_text_size(@ptrCast(BrowserRawPtr, self.inner), val);
+        }
 
-    pub fn fromRaw(ptr: ?*c.Fl_File_Browser) FileBrowser {
-        return FileBrowser{
-            .inner = ptr,
-        };
-    }
+        pub fn topline(self: *const Self, line: u32) void {
+            return c.Fl_Browser_topline(@ptrCast(BrowserRawPtr, self.inner), line);
+        }
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) FileBrowser {
-        return FileBrowser{
-            .inner = @ptrCast(?*c.Fl_File_Browser, w),
-        };
-    }
+        pub fn bottomline(self: *const Self, line: u32) void {
+            return c.Fl_Browser_bottomline(@ptrCast(BrowserRawPtr, self.inner), line);
+        }
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) FileBrowser {
-        return FileBrowser{
-            .inner = @ptrCast(?*c.Fl_File_Browser, ptr),
-        };
-    }
+        pub fn middleline(self: *const Self, line: u32) void {
+            return c.Fl_Browser_middleline(@ptrCast(BrowserRawPtr, self.inner), line);
+        }
 
-    pub fn toVoidPtr(self: *const FileBrowser) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
+        pub fn formatChar(self: *const Self) u8 {
+            return c.Fl_Browser_format_char(@ptrCast(BrowserRawPtr, self.inner));
+        }
 
-    pub fn asWidget(self: *const FileBrowser) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
+        pub fn setFormatChar(self: *const Self, char: u8) void {
+            return c.Fl_Browser_set_format_char(@ptrCast(BrowserRawPtr, self.inner), char);
+        }
 
-    pub fn asBrowser(self: *const FileBrowser) Browser {
-        return Browser{
-            .inner = @ptrCast(?*c.Fl_Browser, self.inner),
-        };
-    }
+        pub fn columnChar(self: *const Self) u8 {
+            return c.Fl_Browser_column_char(@ptrCast(BrowserRawPtr, self.inner));
+        }
 
-    pub fn handle(self: *const FileBrowser, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_File_Browser_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
+        pub fn setColumnChar(self: *const Self, char: u8) void {
+            return c.Fl_Browser_set_column_char(@ptrCast(BrowserRawPtr, self.inner), char);
+        }
 
-    pub fn draw(self: *const FileBrowser, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_File_Browser_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
+        pub fn setColumnWidths(self: *const Self, arr: [:0]const i32) void {
+            return c.Fl_Browser_set_column_widths(@ptrCast(BrowserRawPtr, self.inner), arr.ptr);
+        }
+
+        pub fn displayed(self: *const Self, line: u31) bool {
+            return c.Fl_Browser_displayed(@ptrCast(BrowserRawPtr, self.inner), line) != 0;
+        }
+
+        pub fn makeVisible(self: *const Self, line: u31) void {
+            return c.Fl_Browser_make_visible(@ptrCast(BrowserRawPtr, self.inner), line);
+        }
+
+        pub fn position(self: *const Self) u31 {
+            return c.Fl_Browser_position(@ptrCast(BrowserRawPtr, self.inner));
+        }
+
+        pub fn setPosition(self: *const Self, pos: u31) void {
+            return c.Fl_Browser_set_position(@ptrCast(BrowserRawPtr, self.inner), pos);
+        }
+
+        pub fn hposition(self: *const Self) u31 {
+            return c.Fl_Browser_hposition(@ptrCast(BrowserRawPtr, self.inner));
+        }
+
+        pub fn setHposition(self: *const Self, pos: u31) void {
+            return c.Fl_Browser_set_hposition(@ptrCast(BrowserRawPtr, self.inner), pos);
+        }
+
+        pub fn hasScrollbar(self: *const Self) enums.BrowserScrollbar {
+            return c.Fl_Browser_has_scrollbar(@ptrCast(BrowserRawPtr, self.inner));
+        }
+
+        pub fn setHasScrollbar(self: *const Self, mode: enums.BrowserScrollbar) void {
+            return c.Fl_Browser_set_has_scrollbar(@ptrCast(BrowserRawPtr, self.inner), mode);
+        }
+
+        pub fn scrollbarSize(self: *const Self) u31 {
+            return c.Fl_Browser_scrollbar_size(@ptrCast(BrowserRawPtr, self.inner));
+        }
+
+        pub fn setScrollbarSize(self: *const Self, new_size: u31) void {
+            return c.Fl_Browser_set_scrollbar_size(@ptrCast(BrowserRawPtr, self.inner), new_size);
+        }
+
+        pub fn sort(self: *const Self) void {
+            return c.Fl_Browser_sort(@ptrCast(BrowserRawPtr, self.inner));
+        }
+
+        pub fn scrollbar(self: *const Self) Valuator {
+            return .{ .inner = c.Fl_Browser_scrollbar(@ptrCast(BrowserRawPtr, self.inner)) };
+        }
+
+        pub fn hscrollbar(self: *const Self) .Valuator {
+            return .{ .inner = c.Fl_Browser_hscrollbar(@ptrCast(BrowserRawPtr, self.inner)) };
+        }
+    };
+}
 
 test "all" {
     @import("std").testing.refAllDecls(@This());

--- a/src/button.zig
+++ b/src/button.zig
@@ -1,269 +1,173 @@
-const c = @cImport({
-    @cInclude("cfl_button.h");
-});
+const zfltk = @import("zfltk.zig");
+const app = zfltk.app;
 const widget = @import("widget.zig");
 const Widget = widget.Widget;
 const enums = @import("enums.zig");
+const Event = enums.Event;
+const std = @import("std");
+const c = zfltk.c;
 
-pub const Button = struct {
-    inner: ?*c.Fl_Button,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Button {
-        const ptr = c.Fl_Button_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Button{
-            .inner = ptr,
+pub const ButtonKind = enum {
+    normal,
+    radio,
+    check,
+    round,
+    repeat,
+    light,
+    enter,
+};
+
+pub fn Button(comptime kind: ButtonKind) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace zfltk.widget.methods(Self, RawPtr);
+        pub usingnamespace methods(Self);
+
+        const RawPtr = switch (kind) {
+            .normal => *c.Fl_Button,
+            .radio => *c.Fl_Radio_Button,
+            .check => *c.Fl_Check_Button,
+            .round => *c.Fl_Round_Button,
+            .repeat => *c.Fl_Repeat_Button,
+            .light => *c.Fl_Light_Button,
+            .enter => *c.Fl_Return_Button,
         };
-    }
 
-    pub fn raw(self: *const Button) ?*c.Fl_Button {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Button) Button {
-        return Button{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Button {
-        return Button{
-            .inner = @ptrCast(?*c.Fl_Button, w),
-        };
-    }
-
-    pub fn fromDynWidgetPtr(w: widget.WidgetPtr) ?Button {
-        if (c.Fl_Button_from_dyn_ptr(@ptrCast(?*c.Fl_Widget, w))) |v| {
-            return Button{
-                .inner = v,
+        pub inline fn init(opts: Widget.Options) !*Self {
+            const init_func = switch (kind) {
+                .normal => c.Fl_Button_new,
+                .radio => c.Fl_Radio_Button_new,
+                .check => c.Fl_Check_Button_new,
+                .round => c.Fl_Round_Button_new,
+                .repeat => c.Fl_Repeat_Button_new,
+                .light => c.Fl_Light_Button_new,
+                .enter => c.Fl_Return_Button_new,
             };
-        } else {
+
+            const label = if (opts.label != null) opts.label.?.ptr else null;
+
+            if (init_func(opts.x, opts.y, opts.w, opts.h, label)) |ptr| {
+                return Self.fromRaw(ptr);
+            }
+
+            unreachable;
+        }
+
+        pub inline fn deinit(self: *Self) void {
+            const deinit_func = switch (kind) {
+                .normal => c.Fl_Button_delete,
+                .radio => c.Fl_Radio_Button_delete,
+                .check => c.Fl_Check_Button_delete,
+                .round => c.Fl_Round_Button_delete,
+                .repeat => c.Fl_Repeat_Button_delete,
+                .light => c.Fl_Light_Button_delete,
+                .enter => c.Fl_Return_Button_delete,
+            };
+
+            deinit_func(self.raw());
+            app.allocator.destroy(self);
+        }
+
+        pub inline fn fromDynWidgetPtr(w: *c.Fl_Widget) ?Self {
+            if (c.Fl_Button_from_dyn_ptr(@ptrCast(*c.Fl_Widget, w))) |v| {
+                return .{ .inner = v };
+            }
+
             return null;
         }
-    }
+    };
+}
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Button {
-        return Button{
-            .inner = @ptrCast(?*c.Fl_Button, ptr),
-        };
-    }
+pub fn methods(comptime Self: type) type {
+    return struct {
+        pub inline fn button(self: *Self) *Button(.normal) {
+            return @ptrCast(*Button(.normal), self);
+        }
 
-    pub fn toVoidPtr(self: *const Button) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
+        pub inline fn setEventHandler(self: *Self, comptime f: fn (*Self, Event) bool) void {
+            c.Fl_Button_handle(
+                self.button().raw(),
+                &zfltk_button_event_handler,
+                @intToPtr(*anyopaque, @ptrToInt(&f)),
+            );
+        }
 
-    pub fn asWidget(self: *const Button) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
+        pub inline fn setEventHandlerEx(self: *Self, comptime f: fn (*Self, Event, ?*anyopaque) bool, data: ?*anyopaque) void {
+            var allocator = std.heap.c_allocator;
+            var container = allocator.alloc(usize, 2) catch unreachable;
 
-    pub fn handle(self: *const Button, comptime cb: fn (w: Widget, ev: i32, data: ?*anyopaque) i32, data: ?*anyopaque) void {
-        c.Fl_Button_handle(self.inner, @ptrCast(c.custom_handler_callback, &cb), data);
-    }
+            container[0] = @ptrToInt(&f);
+            container[1] = @ptrToInt(data);
 
-    pub fn draw(self: *const Button, cb: fn (w: Widget, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Button_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
+            c.Fl_Button_handle(
+                self.button().raw(),
+                &zfltk_button_event_handler_ex,
+                @ptrCast(*anyopaque, container.ptr),
+            );
+        }
 
-    pub fn shortcut(self: *const Button) i32 {
-        return c.Fl_Button_shortcut(self.inner);
-    }
+        pub fn draw(self: *const Self, cb: fn (w: Widget, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+            c.Fl_Button_handle(self.button().raw(), @ptrCast(c.custom_draw_callback, cb), data);
+        }
 
-    pub fn setShortcut(self: *const Button, shrtct: i32) void {
-        c.Fl_Button_set_shortcut(self.inner, shrtct);
-    }
+        pub fn shortcut(self: *const Self) i32 {
+            return c.Fl_Button_shortcut(self.button().raw());
+        }
 
-    pub fn clear(self: *const Button) void {
-        c.Fl_Button_clear(self.inner);
-    }
+        pub fn setShortcut(self: *const Self, shrtct: i32) void {
+            c.Fl_Button_set_shortcut(self.button().raw(), shrtct);
+        }
 
-    pub fn value(self: *const Button) bool {
-        return c.Fl_Button_value(self.inner) != 0;
-    }
+        pub fn clear(self: *const Self) void {
+            c.Fl_Button_clear(self.button().raw());
+        }
 
-    pub fn setValue(self: *const Button, flag: bool) void {
-        c.Fl_Button_set_value(self.inner, @boolToInt(flag));
-    }
+        pub fn value(self: *const Self) bool {
+            return c.Fl_Button_value(self.button().raw()) != 0;
+        }
 
-    pub fn setDownBox(self: *const Button, f: enums.BoxType) void {
-        c.Fl_Button_set_down_box(self.inner, f);
-    }
+        pub fn setValue(self: *const Self, flag: bool) void {
+            c.Fl_Button_set_value(self.button().raw(), @boolToInt(flag));
+        }
 
-    pub fn downBox(self: *const Button) enums.BoxType {
-        return c.Fl_Button_down_box(self.inner);
-    }
-};
+        pub fn setDownBox(self: *const Self, f: enums.BoxType) void {
+            c.Fl_Button_set_down_box(self.button().raw(), f);
+        }
 
-pub const RadioButton = struct {
-    inner: ?*c.Fl_Radio_Button,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) RadioButton {
-        const ptr = c.Fl_Radio_Button_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return RadioButton{
-            .inner = ptr,
-        };
-    }
+        pub fn downBox(self: *const Self) enums.BoxType {
+            return c.Fl_Button_down_box(self.button().raw());
+        }
+    };
+}
 
-    pub fn raw(self: *const RadioButton) ?*c.Fl_RadioButton {
-        return self.inner;
-    }
+// TODO: work these into `widget.methods`
+export fn zfltk_button_event_handler(wid: ?*c.Fl_Widget, ev: c_int, data: ?*anyopaque) callconv(.C) c_int {
+    const cb = @ptrCast(
+        *const fn (*Widget, Event) bool,
+        data,
+    );
 
-    pub fn fromRaw(ptr: ?*c.Fl_RadioButton) RadioButton {
-        return RadioButton{
-            .inner = ptr,
-        };
-    }
+    return @boolToInt(cb(
+        Widget.fromRaw(wid.?),
+        @intToEnum(Event, ev),
+    ));
+}
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) RadioButton {
-        return RadioButton{
-            .inner = @ptrCast(?*c.Fl_RadioButton, w),
-        };
-    }
+export fn zfltk_button_event_handler_ex(wid: ?*c.Fl_Widget, ev: c_int, data: ?*anyopaque) callconv(.C) c_int {
+    const container = @ptrCast(*[2]usize, @alignCast(@sizeOf(usize), data));
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) RadioButton {
-        return RadioButton{
-            .inner = @ptrCast(?*c.Fl_RadioButton, ptr),
-        };
-    }
+    const cb = @intToPtr(
+        *const fn (*Widget, Event, ?*anyopaque) bool,
+        container[0],
+    );
 
-    pub fn toVoidPtr(self: *const RadioButton) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const RadioButton) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asButton(self: *const RadioButton) Button {
-        return Button{
-            .inner = @ptrCast(?*c.Fl_Button, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const RadioButton, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Radio_Button_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const RadioButton, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Radio_Button_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
-
-pub const CheckButton = struct {
-    inner: ?*c.Fl_Check_Button,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) CheckButton {
-        const ptr = c.Fl_Check_Button_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return CheckButton{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const CheckButton) ?*c.Fl_CheckButton {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_CheckButton) CheckButton {
-        return CheckButton{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) CheckButton {
-        return CheckButton{
-            .inner = @ptrCast(?*c.Fl_CheckButton, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) CheckButton {
-        return CheckButton{
-            .inner = @ptrCast(?*c.Fl_CheckButton, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const CheckButton) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const CheckButton) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asButton(self: *const CheckButton) Button {
-        return Button{
-            .inner = @ptrCast(?*c.Fl_Button, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const CheckButton, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) i32, data: ?*anyopaque) void {
-        c.Fl_Check_Button_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const CheckButton, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) void, data: ?*anyopaque) void {
-        c.Fl_Check_Button_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
-
-pub const RoundButton = struct {
-    inner: ?*c.Fl_Round_Button,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) RoundButton {
-        const ptr = c.Fl_Round_Button_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return RoundButton{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const RoundButton) ?*c.Fl_RoundButton {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_RoundButton) RoundButton {
-        return RoundButton{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) RoundButton {
-        return RoundButton{
-            .inner = @ptrCast(?*c.Fl_RoundButton, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) RoundButton {
-        return RoundButton{
-            .inner = @ptrCast(?*c.Fl_RoundButton, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const RoundButton) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const RoundButton) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asButton(self: *const RoundButton) Button {
-        return Button{
-            .inner = @ptrCast(?*c.Fl_Button, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const RoundButton, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Round_Button_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const RoundButton, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Round_Button_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
+    return @boolToInt(cb(
+        Widget.fromRaw(wid.?),
+        @intToEnum(Event, ev),
+        @intToPtr(?*anyopaque, container[1]),
+    ));
+}
 
 test "all" {
     @import("std").testing.refAllDecls(@This());

--- a/src/dialog.zig
+++ b/src/dialog.zig
@@ -1,86 +1,102 @@
-const c = @cImport({
-    @cInclude("cfl_dialog.h");
-});
+// TODO: update to new API
 
-pub const NativeFileDialogType = enum(i32) {
-    /// Browse files
-    BrowseFile = 0,
-    /// Browse dir
-    BrowseDir,
-    /// Browse multiple files
-    BrowseMultiFile,
-    /// Browse multiple dirs
-    BrowseMultiDir,
-    /// Browse save file
-    BrowseSaveFile,
-    /// Browse save directory
-    BrowseSaveDir,
+const zfltk = @import("zfltk.zig");
+const c = zfltk.c;
+const std = @import("std");
+
+pub const FileDialogKind = enum(c_int) {
+    file = 0,
+    dir,
+    multi_file,
+    multi_dir,
+    save_file,
+    save_dir,
 };
 
-pub const NativeFileDialogOptions = enum(i32) {
-    /// No options
-    NoOptions = 0,
-    /// Confirm on save as
-    SaveAsConfirm = 1,
-    /// New folder option
-    NewFolder = 2,
-    /// Enable preview
-    Preview = 4,
-    /// Use extension filter
-    UseFilterExt = 8,
-};
+// TODO: refactor to contain all dialog types
+pub fn FileDialog(comptime kind: FileDialogKind) type {
+    return struct {
+        const Self = @This();
 
-pub const NativeFileDialog = struct {
-    inner: ?*c.Fl_Native_File_Chooser,
-    pub fn new(typ: NativeFileDialogType) NativeFileDialog {
-        return NativeFileDialog{
-            .inner = c.Fl_Native_File_Chooser_new(@enumToInt(typ)),
+        pub usingnamespace zfltk.widget.methods(Self, *c.Fl_Native_File_Chooser);
+
+        pub const Options = struct {
+            save_as_confirm: bool = false,
+            new_folder: bool = false,
+            preview: bool = false,
+            use_filter_extension: bool = false,
+
+            filter: ?[:0]const u8 = null,
         };
-    }
 
-    pub fn setOptions(self: *const NativeFileDialog, opt: NativeFileDialogOptions) void {
-        c.Fl_Native_File_Chooser_set_option(self.inner, @enumToInt(opt));
-    }
+        pub inline fn init(opts: Options) !*Self {
+            // Convert bools to OR'd int
+            const save_as_confirm = @intCast(c_int, @boolToInt(opts.save_as_confirm));
+            const new_folder = @intCast(c_int, @boolToInt(opts.new_folder)) << 1;
+            const preview = @intCast(c_int, @boolToInt(opts.preview)) << 2;
+            const use_filter_extension = @intCast(c_int, @boolToInt(opts.use_filter_extension)) << 3;
 
-    pub fn show(self: *const NativeFileDialog) void {
-        _ = c.Fl_Native_File_Chooser_show(self.inner);
-    }
+            const flags = save_as_confirm | new_folder | preview | use_filter_extension;
 
-    pub fn filename(self: *const NativeFileDialog) [*c]const u8 {
-        return c.Fl_Native_File_Chooser_filenames(self.inner, 0);
-    }
+            if (c.Fl_Native_File_Chooser_new(flags)) |ptr| {
+                const self = Self.fromRaw(ptr);
 
-    pub fn filenameAt(self: *const NativeFileDialog, idx: u32) [*c]const u8 {
-        return c.Fl_Native_File_Chooser_filenames(self.inner, idx);
-    }
+                if (opts.filter) |filter| {
+                    self.setFilter(filter);
+                }
 
-    pub fn count(self: *const NativeFileDialog) u32 {
-        return c.Fl_Native_File_Chooser_count(self.inner);
-    }
+                self.setOptions(kind);
 
-    pub fn setDirectory(self: *const NativeFileDialog, dir: [*c]const u8) void {
-        c.Fl_Native_File_Chooser_set_directory(self.inner, dir);
-    }
+                return Self.fromRaw(ptr);
+            }
 
-    pub fn directory(self: *const NativeFileDialog) [*c][]const u8 {
-        return c.Fl_Native_File_Chooser_directory(self.inner);
-    }
+            unreachable;
+        }
 
-    /// Sets the filter for the dialog, can be:
-    /// A single wildcard (eg. "*.txt")
-    /// Multiple wildcards (eg. "*.{cxx,h,H}")
-    /// A descriptive name followed by a "\t" and a wildcard (eg. "Text Files\t*.txt")
-    /// A list of separate wildcards with a "\n" between each (eg. "*.{cxx,H}\n*.txt")
-    /// A list of descriptive names and wildcards (eg. "C++ Files\t*.{cxx,H}\nTxt Files\t*.txt")
-    pub fn setFilter(self: *const NativeFileDialog, f: [*c]const u8) void {
-        c.Fl_Native_File_Chooser_set_filter(self.inner, f);
-    }
+        pub inline fn dialog(self: *Self) *FileDialog(.file) {
+            return @ptrCast(*FileDialog(.file), self);
+        }
 
-    /// Sets the preset filter for the dialog
-    pub fn setPresetFile(self: *const NativeFileDialog, f: [*c]const u8) void {
-        c.Fl_Native_File_Chooser_set_preset_file(self.inner, f);
-    }
-};
+        pub fn setOptions(self: *Self, opt: FileDialogKind) void {
+            c.Fl_Native_File_Chooser_set_option(self.raw(), @enumToInt(opt));
+        }
+
+        pub fn filename(self: *Self) [:0]const u8 {
+            return std.mem.span(c.Fl_Native_File_Chooser_filenames(self.raw(), 0));
+        }
+
+        pub fn filenameAt(self: *Self, idx: u32) [*c]const u8 {
+            return c.Fl_Native_File_Chooser_filenames(self.raw(), idx);
+        }
+
+        pub fn count(self: *Self) u32 {
+            return c.Fl_Native_File_Chooser_count(self.raw());
+        }
+
+        pub fn setDirectory(self: *Self, dir: [:0]const u8) void {
+            c.Fl_Native_File_Chooser_set_directory(self.raw(), dir.ptr);
+        }
+
+        pub fn directory(self: *Self) [*c][]const u8 {
+            return c.Fl_Native_File_Chooser_directory(self.raw());
+        }
+
+        /// Sets the filter for the dialog, can be:
+        /// A single wildcard (eg. "*.txt")
+        /// Multiple wildcards (eg. "*.{cxx,h,H}")
+        /// A descriptive name followed by a "\t" and a wildcard (eg. "Text Files\t*.txt")
+        /// A list of separate wildcards with a "\n" between each (eg. "*.{cxx,H}\n*.txt")
+        /// A list of descriptive names and wildcards (eg. "C++ Files\t*.{cxx,H}\nTxt Files\t*.txt")
+        pub inline fn setFilter(self: *Self, f: [:0]const u8) void {
+            c.Fl_Native_File_Chooser_set_filter(self.dialog().raw(), f.ptr);
+        }
+
+        /// Sets the preset filter for the dialog
+        pub inline fn setPresetFile(self: *Self, f: [:0]const u8) void {
+            c.Fl_Native_File_Chooser_set_preset_file(self.raw(), f.ptr);
+        }
+    };
+}
 
 /// Displays an message box
 pub fn message(x: i32, y: i32, msg: [*c]const u8) void {

--- a/src/draw.zig
+++ b/src/draw.zig
@@ -425,8 +425,8 @@ pub fn drawFrame2(string: [*c]const u8, x: i32, y: i32, w: i32, h: i32) void {
 }
 
 /// Draws a box given the box type, size, position and color
-pub fn drawBox(box_type: BoxType, x: i32, y: i32, w: i32, h: i32, col: Color) void {
-    c.Fl_draw_box(box_type, x, y, w, h, col.toRgbi());
+pub fn box(box_type: BoxType, x: i32, y: i32, w: i32, h: i32, col: Color) void {
+    c.Fl_draw_box(@enumToInt(box_type), x, y, w, h, col.toRgbi());
 }
 
 /// Checks whether platform supports true alpha blending for RGBA images

--- a/src/group.zig
+++ b/src/group.zig
@@ -1,420 +1,254 @@
-const c = @cImport({
-    @cInclude("cfl_group.h");
-});
-const widget = @import("widget.zig");
-const Widget = widget.Widget;
+const zfltk = @import("zfltk.zig");
+const app = zfltk.app;
+const Widget = zfltk.Widget;
+const c = zfltk.c;
+const std = @import("std");
+const widget_methods = zfltk.widget_methods;
 
 pub const GroupPtr = ?*c.Fl_Group;
 
-pub const Group = struct {
-    inner: ?*c.Fl_Group,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Group {
-        const ptr = c.Fl_Group_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Group{
-            .inner = ptr,
-        };
-    }
-
-    pub fn current() Group {
-        return Group{
-            .inner = c.Fl_Group_current(),
-        };
-    }
-
-    pub fn raw(self: *const Group) ?*c.Fl_Group {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Group) Group {
-        return Group{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Group {
-        return Group{
-            .inner = @ptrCast(?*c.Fl_Group, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Group {
-        return Group{
-            .inner = @ptrCast(?*c.Fl_Group, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Group) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Group) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Group, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Group_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Group, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Group_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-
-    pub fn begin(self: *const Group) void {
-        c.Fl_Group_begin(self.inner);
-    }
-
-    pub fn end(self: *const Group) void {
-        c.Fl_Group_end(self.inner);
-    }
-
-    pub fn find(self: *const Group, w: *const widget.Widget) u32 {
-        return c.Fl_Group_find(self.inner, w.*.raw());
-    }
-
-    pub fn add(self: *const Group, w: *const widget.Widget) void {
-        return c.Fl_Group_add(self.inner, w.*.raw());
-    }
-
-    pub fn insert(self: *const Group, w: *const widget.Widget, index: u32) void {
-        return c.Fl_Group_insert(self.inner, w.*.raw(), index);
-    }
-
-    pub fn remove(self: *const Group, w: *const widget.Widget) void {
-        return c.Fl_Group_remove(self.inner, w.*.raw());
-    }
-
-    pub fn resizable(self: *const Group, w: *const widget.Widget) void {
-        return c.Fl_Group_resizable(self.inner, w.*.raw());
-    }
-
-    pub fn clear(self: *const Group) void {
-        c.Fl_Group_clear(self.inner);
-    }
-
-    pub fn children(self: *const Group) u32 {
-        c.Fl_Group_children(self.inner);
-    }
-
-    pub fn child(self: *const Group, idx: u32) !widget.Widget {
-        const ptr = c.Fl_Group_child(self.inner, idx);
-        if (ptr == 0) unreachable;
-        return widget.Widget{
-            .inner = ptr,
-        };
-    }
+pub const GroupKind = enum {
+    normal,
+    pack,
+    tabs,
+    scroll,
+    flex,
 };
 
-pub const PackType = enum(i32) {
-    Vertical = 0,
-    Horizontal = 1,
-};
-
-pub const Pack = struct {
-    inner: ?*c.Fl_Pack,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Pack {
-        const ptr = c.Fl_Pack_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Pack{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Pack) ?*c.Fl_Pack {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Pack) Pack {
-        return Pack{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Pack {
-        return Pack{
-            .inner = @ptrCast(?*c.Fl_Pack, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Pack {
-        return Pack{
-            .inner = @ptrCast(?*c.Fl_Pack, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Pack) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Pack) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asGroup(self: *const Pack) Group {
-        return Group{
-            .inner = @ptrCast(?*c.Fl_Group, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Pack, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Pack_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Pack, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Pack_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-
-    /// Get the spacing of the pack
-    pub fn spacing(self: *const Pack) i32 {
-        return c.Fl_Pack_spacing(self.inner);
-    }
-
-    /// Set the spacing of the pack
-    pub fn setSpacing(self: *const Pack, s: i32) void {
-        c.Fl_Pack_set_spacing(self.inner, s);
-    }
-};
-
-pub const Tabs = struct {
-    inner: ?*c.Fl_Tabs,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Tabs {
-        const ptr = c.Fl_Tabs_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Tabs{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Tabs) ?*c.Fl_Tabs {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Tabs) Tabs {
-        return Tabs{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Tabs {
-        return Tabs{
-            .inner = @ptrCast(?*c.Fl_Tabs, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Tabs {
-        return Tabs{
-            .inner = @ptrCast(?*c.Fl_Tabs, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Tabs) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Tabs) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asGroup(self: *const Tabs) Group {
-        return Group{
-            .inner = @ptrCast(?*c.Fl_Group, self.inner),
-        };
-    }
-
-    pub fn setHandle(self: *const Tabs, cb: fn (w: Widget, ev: i32) i32) void {
-        c.Fl_Tabs_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), null);
-    }
-
-    pub fn setHandleEx(self: *const Tabs, cb: fn (w: Widget, ev: i32, data: ?*anyopaque) i32, data: ?*anyopaque) void {
-        c.Fl_Tabs_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Tabs, cb: fn (w: Widget, data: ?*anyopaque) void, data: ?*anyopaque) void {
-        c.Fl_Tabs_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-
-    /// Gets the currently visible group
-    pub fn value(self: *const Tabs) Group {
-        return Group{ .inner = c.Fl_Tabs_value(self.inner) };
-    }
-
-    /// Sets the currently visible group
-    pub fn set_value(self: *const Tabs, w: *const Group) void {
-        _ = c.Fl_Tabs_set_value(self.inner, w);
-    }
-
-    /// Sets the tab label alignment
-    pub fn set_tab_align(self: *const Tabs, a: i32) void {
-        c.Fl_Tabs_set_tab_align(self.inner, a);
-    }
-
-    /// Gets the tab label alignment.
-    pub fn tab_align(self: *const Tabs) i32 {
-        return c.Fl_Tabs_tab_align(self.inner);
-    }
-};
-
-pub const ScrollType = enum(i32) {
+pub const ScrollType = enum(c_int) {
     /// Never show bars
-    None = 0,
+    none = 0,
     /// Show vertical bar
-    Horizontal = 1,
+    horizontal = 1,
     /// Show vertical bar
-    Vertical = 2,
+    vertical = 2,
     /// Show both horizontal and vertical bars
-    Both = 3,
+    both = 3,
     /// Always show bars
-    AlwaysOn = 4,
+    always_on = 4,
     /// Show horizontal bar always
-    HorizontalAlways = 5,
+    horizontal_always = 5,
     /// Show vertical bar always
-    VerticalAlways = 6,
+    vertical_always = 6,
     /// Always show both horizontal and vertical bars
-    BothAlways = 7,
+    both_always = 7,
 };
 
-pub const Scroll = struct {
-    inner: ?*c.Fl_Scroll,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Scroll {
-        const ptr = c.Fl_Scroll_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Scroll{
-            .inner = ptr,
+pub fn Group(comptime kind: GroupKind) type {
+    return struct {
+        const Self = @This();
+
+        // Expose methods from `inherited` structs
+        pub usingnamespace zfltk.widget.methods(Self, RawPtr);
+        pub usingnamespace methods(Self);
+
+        const GroupRawPtr = *c.Fl_Group;
+
+        pub const RawPtr = switch (kind) {
+            .normal => *c.Fl_Group,
+            .pack => *c.Fl_Pack,
+            .tabs => *c.Fl_Tabs,
+            .scroll => *c.Fl_Scroll,
+            .flex => *c.Fl_Flex,
         };
-    }
 
-    pub fn raw(self: *const Scroll) ?*c.Fl_Scroll {
-        return self.inner;
-    }
+        pub const Options = struct {
+            x: u31 = 0,
+            y: u31 = 0,
+            w: u31 = 0,
+            h: u31 = 0,
 
-    pub fn fromRaw(ptr: ?*c.Fl_Scroll) Scroll {
-        return Scroll{
-            .inner = ptr,
+            spacing: u31 = 0,
+
+            label: ?[:0]const u8 = null,
+            orientation: Orientation = .vertical,
+
+            pub const Orientation = enum {
+                vertical,
+                horizontal,
+            };
         };
-    }
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Scroll {
-        return Scroll{
-            .inner = @ptrCast(?*c.Fl_Scroll, w),
-        };
-    }
+        pub inline fn init(opts: Options) !*Self {
+            const initFn = switch (kind) {
+                .normal => c.Fl_Group_new,
+                .pack => c.Fl_Pack_new,
+                .tabs => c.Fl_Tabs_new,
+                .scroll => c.Fl_Scroll_new,
+                .flex => c.Fl_Flex_new,
+            };
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Scroll {
-        return Scroll{
-            .inner = @ptrCast(?*c.Fl_Scroll, ptr),
-        };
-    }
+            const label = if (opts.label != null) opts.label.?.ptr else null;
 
-    pub fn toVoidPtr(self: *const Scroll) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
+            if (initFn(opts.x, opts.y, opts.w, opts.h, label)) |ptr| {
+                var self = Self.fromRaw(ptr);
 
-    pub fn asWidget(self: *const Scroll) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
+                switch (kind) {
+                    .pack, .flex => {
+                        self.setSpacing(opts.spacing);
 
-    pub fn asGroup(self: *const Scroll) Group {
-        return Group{
-            .inner = @ptrCast(?*c.Fl_Group, self.inner),
-        };
-    }
+                        if (opts.orientation != .vertical) {
+                            c.Fl_Widget_set_type(self.widget().raw(), 1);
+                        }
+                    },
+                    else => {},
+                }
 
-    pub fn handle(self: *const Scroll, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Scroll_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
+                return self;
+            }
 
-    pub fn draw(self: *const Scroll, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Scroll_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
+            unreachable;
+        }
+    };
+}
 
-pub const FlexType = enum(i32) {
-    Vertical = 0,
-    Horizontal = 1,
-};
+pub fn methods(comptime Self: type) type {
+    return struct {
+        pub inline fn group(self: *Self) *Group(.normal) {
+            return @ptrCast(*Group(.normal), self);
+        }
 
-pub const Flex = struct {
-    inner: ?*c.Fl_Flex,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Flex {
-        const ptr = c.Fl_Flex_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Flex{
-            .inner = ptr,
-        };
-    }
+        pub inline fn current() Self {
+            if (c.Fl_Group_current()) |grp| {
+                return Self.fromRaw(grp);
+            }
 
-    pub fn raw(self: *const Flex) ?*c.Fl_Flex {
-        return self.inner;
-    }
+            unreachable;
+        }
 
-    pub fn fromRaw(ptr: ?*c.Fl_Flex) Flex {
-        return Flex{
-            .inner = ptr,
-        };
-    }
+        pub fn handle(self: *Self, cb: fn (w: Widget.RawPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
+            c.Fl_Group_handle(self.raw(), @ptrCast(c.custom_handler_callback, cb), data);
+        }
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Flex {
-        return Flex{
-            .inner = @ptrCast(?*c.Fl_Flex, w),
-        };
-    }
+        pub fn draw(self: *Self, cb: fn (w: Widget.RawPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+            c.Fl_Group_handle(self.raw(), @ptrCast(c.custom_draw_callback, cb), data);
+        }
 
-    pub fn end(self: *const Flex) void {
-        c.Fl_Flex_end(self.inner);
-    }
+        pub fn begin(self: *Self) void {
+            c.Fl_Group_begin(self.group().raw());
+        }
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Flex {
-        return Flex{
-            .inner = @ptrCast(?*c.Fl_Flex, ptr),
-        };
-    }
+        pub fn end(self: *Self) void {
+            const endFn = switch (Self) {
+                Group(.flex) => c.Fl_Flex_end,
+                else => c.Fl_Group_end,
+            };
 
-    pub fn toVoidPtr(self: *const Flex) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
+            const ptr = switch (Self) {
+                Group(.flex) => self.raw(),
+                else => self.group().raw(),
+            };
 
-    pub fn asWidget(self: *const Flex) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
+            endFn(ptr);
+        }
 
-    pub fn asGroup(self: *const Flex) Group {
-        return Group{
-            .inner = @ptrCast(?*c.Fl_Group, self.inner),
-        };
-    }
+        pub fn find(self: *const Self, wid: *const Widget) u32 {
+            return c.Fl_Group_find(self.group().raw(), wid.raw());
+        }
 
-    pub fn handle(self: *const Flex, cb: fn (w: Widget, ev: i32, data: ?*anyopaque) i32, data: ?*anyopaque) void {
-        c.Fl_Flex_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
+        pub fn add(self: *Self, widgets: anytype) void {
+            const T = @TypeOf(widgets);
+            const type_info = @typeInfo(T);
 
-    pub fn draw(self: *const Flex, cb: fn (w: Widget, data: ?*anyopaque) void, data: ?*anyopaque) void {
-        c.Fl_Flex_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
+            if (type_info != .Struct) {
+                @compileError("expected tuple or struct argument, found " ++ @typeName(T));
+            }
 
-    /// Set the size of the child
-    pub fn fixed(self: *const Flex, w: *const Widget, sz: i32) void {
-        c.Fl_Flex_set_size(self.inner, @ptrCast(*c.Fl_Widget, w.*.raw()), sz);
-    }
+            inline for (std.meta.fields(T)) |w| {
+                const wid = @as(w.field_type, @field(widgets, w.name));
 
-    pub fn setPad(self: *const Flex, sz: i32) void {
-        c.Fl_Flex_set_pad(self.inner, sz);
-    }
+                if (!comptime zfltk.isWidget(w.field_type)) {
+                    @compileError("expected FLTK widget, found " ++ @typeName(w.field_type));
+                }
 
-    pub fn setMargin(self: *const Flex, sz: i32) void {
-        c.Fl_Flex_set_margin(self.inner, sz);
-    }
-};
+                c.Fl_Group_add(self.group().raw(), wid.widget().raw());
+            }
+        }
 
-test "all" {
-    @import("std").testing.refAllDecls(@This());
+        pub fn insert(self: *const Self, wid: anytype, index: u32) void {
+            const T = @TypeOf(wid);
+            if (!comptime zfltk.isWidget(T)) {
+                @compileError("expected FLTK widget, found " ++ @typeName(T));
+            }
+
+            return c.Fl_Group_insert(self.group().raw(), wid.raw(), index);
+        }
+
+        pub fn remove(self: *const Self, wid: anytype) void {
+            const T = @TypeOf(wid);
+            if (!comptime zfltk.isWidget(T)) {
+                @compileError("expected FLTK widget, found " ++ @typeName(T));
+            }
+
+            return c.Fl_Group_remove(self.group().raw(), wid.raw());
+        }
+
+        pub fn resizable(self: *Self, wid: anytype) void {
+            const T = @TypeOf(wid);
+            if (!comptime zfltk.isWidget(T)) {
+                @compileError("expected FLTK widget, found " ++ @typeName(T));
+            }
+
+            return c.Fl_Group_resizable(self.group().raw(), wid.raw());
+        }
+
+        pub fn clear(self: *const Self) void {
+            c.Fl_Group_clear(self.group().raw());
+        }
+
+        pub fn children(self: *const Self) u31 {
+            c.Fl_Group_children(self.group().raw());
+        }
+
+        pub fn child(self: *const Self, idx: u31) !Widget {
+            if (c.Fl_Group_child(self.group().raw(), idx)) |ptr| {
+                return Widget.fromRaw(ptr);
+            }
+
+            return null;
+        }
+
+        pub fn spacing(self: *const Self) u31 {
+            const spacingFn = switch (Self) {
+                Group(.flex) => c.Fl_Flex_pad,
+                Group(.pack) => c.Fl_Pack_spacing,
+
+                else => @compileError("method `spacing` only usable with flex and pack groups"),
+            };
+
+            return @intCast(u31, spacingFn(self.raw()));
+        }
+
+        pub fn setSpacing(self: *Self, sz: u31) void {
+            const spacingFn = switch (Self) {
+                Group(.flex) => c.Fl_Flex_set_pad,
+                Group(.pack) => c.Fl_Pack_set_spacing,
+
+                else => @compileError("method `setSpacing` only usable with flex and pack groups"),
+            };
+
+            spacingFn(self.raw(), sz);
+        }
+
+        pub inline fn fixed(self: *Self, wid: anytype, sz: i32) void {
+            if (Self != Group(.flex)) {
+                @compileError("method `fixed` only usable with flex groups");
+            }
+
+            const T = @TypeOf(wid);
+            if (!comptime zfltk.isWidget(T)) {
+                @compileError("expected FLTK widget, found " ++ @typeName(T));
+            }
+
+            c.Fl_Flex_set_size(self.raw(), wid.widget().raw(), sz);
+        }
+
+        pub inline fn setScrollBar(self: *Self, scrollbar: ScrollType) void {
+            if (Self != Group(.scroll)) {
+                @compileError("method `setScrollBar` only usable with scroll groups");
+            }
+
+            self.widget().setKind(ScrollType, scrollbar);
+        }
+    };
 }

--- a/src/menu.zig
+++ b/src/menu.zig
@@ -86,12 +86,12 @@ pub const Menu = struct {
         c.Fl_Menu_Bar_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
     }
 
-    pub fn add(self: *const Menu, name: [*c]const u8, shortcut: i32, flag: MenuFlag, comptime f: fn (w: Widget) void, data: ?*anyopaque) void {
-        _ = c.Fl_Menu_Bar_add(self.inner, name, shortcut, @ptrCast(*const fn (?*c.Fl_Widget, ?*anyopaque) callconv(.C) void, &f), data, @enumToInt(flag));
+    pub fn add(self: *const Menu, name: [*c]const u8, shortcut: i32, flag: MenuFlag, f: *const fn (w: *Widget) void) void {
+        _ = c.Fl_Menu_Bar_add(self.inner, name, shortcut, @ptrCast(*const fn (?*c.Fl_Widget, ?*anyopaque) callconv(.C) void, f), null, @enumToInt(flag));
     }
 
-    pub fn addEx(self: *const Menu, name: [*c]const u8, shortcut: i32, flag: MenuFlag, comptime f: fn (w: Widget, data: ?*anyopaque) void, data: ?*anyopaque) void {
-        _ = c.Fl_Menu_Bar_add(self.inner, name, shortcut, @ptrCast(*const fn (?*c.Fl_Widget, ?*anyopaque) callconv(.C) void, &f), data, @enumToInt(flag));
+    pub fn addEx(self: *const Menu, name: [*c]const u8, shortcut: i32, flag: MenuFlag, f: *const fn (w: *Widget, data: ?*anyopaque) void, data: ?*anyopaque) void {
+        _ = c.Fl_Menu_Bar_add(self.inner, name, shortcut, @ptrCast(*const fn (?*c.Fl_Widget, ?*anyopaque) callconv(.C) void, f), data, @enumToInt(flag));
     }
 
     pub fn insert(self: *const Menu, idx: u32, name: [*c]const u8, shortcut: i32, flag: MenuFlag, cb: fn (w: ?*c.Fl_Widget, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {

--- a/src/table.zig
+++ b/src/table.zig
@@ -1,3 +1,5 @@
+//TODO: update to new API
+
 const c = @cImport({
     @cInclude("cfl_table.h");
 });

--- a/src/tree.zig
+++ b/src/tree.zig
@@ -1,3 +1,5 @@
+//TODO: update to new API
+
 const c = @cImport({
     @cInclude("cfl_tree.h");
 });

--- a/src/valuator.zig
+++ b/src/valuator.zig
@@ -1,118 +1,14 @@
-const c = @cImport({
-    @cInclude("cfl_valuator.h");
-});
-const widget = @import("widget.zig");
+const zfltk = @import("zfltk.zig");
+const Widget = zfltk.Widget;
+const c = zfltk.c;
 
-pub const Valuator = struct {
-    inner: ?*c.Fl_Slider,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Valuator {
-        const ptr = c.Fl_Slider_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Valuator{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Valuator) ?*c.Fl_Slider {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Slider) Valuator {
-        return Valuator{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Valuator {
-        return Valuator{
-            .inner = @ptrCast(?*c.Fl_Slider, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Valuator {
-        return Valuator{
-            .inner = @ptrCast(?*c.Fl_Slider, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Valuator) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Valuator) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Valuator, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Slider_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Valuator, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Slider_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-
-    /// Set bounds of a valuator
-    pub fn setBounds(self: *const Valuator, a: f64, b: f64) void {
-        return c.Fl_Slider_set_bounds(self.inner, a, b);
-    }
-    /// Get the minimum bound of a valuator
-    pub fn minimum(self: *const Valuator) f64 {
-        return c.Fl_Slider_minimum(self.inner);
-    }
-    /// Set the minimum bound of a valuator
-    pub fn setMinimum(self: *const Valuator, a: f64) void {
-        return c.Fl_Slider_set_minimum(self.inner, a);
-    }
-    /// Get the maximum bound of a valuator
-    pub fn maximum(self: *const Valuator) f64 {
-        return c.Fl_Slider_maximum(self.inner);
-    }
-    /// Set the maximum bound of a valuator
-    pub fn setMaximum(self: *const Valuator, a: f64) void {
-        return c.Fl_Slider_set_maximum(self.inner, a);
-    }
-    /// Set the range of a valuator
-    pub fn setRange(self: *const Valuator, a: f64, b: f64) void {
-        return c.Fl_Slider_set_range(self.inner, a, b);
-    }
-    /// Set change step of a valuator
-    pub fn setStep(self: *const Valuator, a: f64, b: i32) void {
-        return c.Fl_Slider_set_step(self.inner, a, b);
-    }
-    /// Get change step of a valuator
-    pub fn step(self: *const Valuator) f64 {
-        return c.Fl_Slider_step(self.inner);
-    }
-    /// Set the precision of a valuator
-    pub fn setPrecision(self: *const Valuator, digits: i32) void {
-        return c.Fl_Slider_set_precision(self.inner, digits);
-    }
-    /// Get the value of a valuator
-    pub fn value(self: *const Valuator) f64 {
-        return c.Fl_Slider_value(self.inner);
-    }
-    /// Set the value of a valuator
-    pub fn setValue(self: *const Valuator, arg2: f64) void {
-        return c.Fl_Slider_set_value(self.inner, arg2);
-    }
-    /// Set the format of a valuator
-    pub fn format(self: *const Valuator, arg2: [*c]const u8) void {
-        return c.Fl_Slider_format(self.inner, arg2);
-    }
-    /// Round the valuator
-    pub fn round(self: *const Valuator, arg2: f64) f64 {
-        return c.Fl_Slider_round(self.inner, arg2);
-    }
-    /// Clamp the valuator
-    pub fn clamp(self: *const Valuator, arg2: f64) f64 {
-        return c.Fl_Slider_clamp(self.inner, arg2);
-    }
-    /// Increment the valuator
-    pub fn increment(self: *const Valuator, arg2: f64, arg3: i32) f64 {
-        return c.Fl_Slider_increment(self.inner, arg2, arg3);
-    }
+pub const ValuatorKind = enum {
+    slider,
+    dial,
+    counter,
+    scrollbar,
+    adjuster,
+    roller,
 };
 
 pub const SliderType = enum(i32) {
@@ -130,193 +26,6 @@ pub const SliderType = enum(i32) {
     HorizontalNice = 5,
 };
 
-pub const Slider = struct {
-    inner: ?*c.Fl_Slider,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Slider {
-        const ptr = c.Fl_Slider_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Slider{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Slider) ?*c.Fl_Slider {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Slider) Slider {
-        return Slider{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Slider {
-        return Slider{
-            .inner = @ptrCast(?*c.Fl_Slider, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Slider {
-        return Slider{
-            .inner = @ptrCast(?*c.Fl_Slider, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Slider) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Slider) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asValuator(self: *const Slider) Valuator {
-        return Valuator{
-            .inner = @ptrCast(?*c.Fl_Slider, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Slider, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Slider_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Slider, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Slider_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
-
-pub const DialType = enum(i32) {
-    /// Normal dial
-    Normal = 0,
-    /// Line dial
-    Line = 1,
-    /// Filled dial
-    Fill = 2,
-};
-
-pub const Dial = struct {
-    inner: ?*c.Fl_Dial,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Dial {
-        const ptr = c.Fl_Dial_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Dial{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Dial) ?*c.Fl_Dial {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Dial) Dial {
-        return Dial{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Dial {
-        return Dial{
-            .inner = @ptrCast(?*c.Fl_Dial, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Dial {
-        return Dial{
-            .inner = @ptrCast(?*c.Fl_Dial, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Dial) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Dial) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asValuator(self: *const Dial) Valuator {
-        return Valuator{
-            .inner = @ptrCast(?*c.Fl_Dial, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Dial, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Dial_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Dial, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Dial_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
-
-pub const CounterType = enum(i32) {
-    /// Normal counter
-    Normal = 0,
-    /// Simple counter
-    Simple = 1,
-};
-
-pub const Counter = struct {
-    inner: ?*c.Fl_Counter,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Counter {
-        const ptr = c.Fl_Counter_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Counter{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Counter) ?*c.Fl_Counter {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Counter) Counter {
-        return Counter{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Counter {
-        return Counter{
-            .inner = @ptrCast(?*c.Fl_Counter, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Counter {
-        return Counter{
-            .inner = @ptrCast(?*c.Fl_Counter, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Counter) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Counter) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asValuator(self: *const Counter) Valuator {
-        return Valuator{
-            .inner = @ptrCast(?*c.Fl_Counter, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Counter, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Counter_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Counter, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Counter_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
-
 pub const ScrollbarType = enum(i32) {
     /// Vertical scrollbar
     Vertical = 0,
@@ -332,176 +41,186 @@ pub const ScrollbarType = enum(i32) {
     HorizontalNice = 5,
 };
 
-pub const Scrollbar = struct {
-    inner: ?*c.Fl_Scrollbar,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Scrollbar {
-        const ptr = c.Fl_Scrollbar_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Scrollbar{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Scrollbar) ?*c.Fl_Scrollbar {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Scrollbar) Scrollbar {
-        return Scrollbar{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Scrollbar {
-        return Scrollbar{
-            .inner = @ptrCast(?*c.Fl_Scrollbar, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Scrollbar {
-        return Scrollbar{
-            .inner = @ptrCast(?*c.Fl_Scrollbar, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Scrollbar) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Scrollbar) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asValuator(self: *const Scrollbar) Valuator {
-        return Valuator{
-            .inner = @ptrCast(?*c.Fl_Scrollbar, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Scrollbar, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Scrollbar_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Scrollbar, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Scrollbar_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
+pub const DialType = enum(i32) {
+    /// Normal dial
+    Normal = 0,
+    /// Line dial
+    Line = 1,
+    /// Filled dial
+    Fill = 2,
 };
 
-pub const Adjuster = struct {
-    inner: ?*c.Fl_Adjuster,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Adjuster {
-        const ptr = c.Fl_Adjuster_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Adjuster{
-            .inner = ptr,
-        };
-    }
-
-    pub fn raw(self: *const Adjuster) ?*c.Fl_Adjuster {
-        return self.inner;
-    }
-
-    pub fn fromRaw(ptr: ?*c.Fl_Adjuster) Adjuster {
-        return Adjuster{
-            .inner = ptr,
-        };
-    }
-
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Adjuster {
-        return Adjuster{
-            .inner = @ptrCast(?*c.Fl_Adjuster, w),
-        };
-    }
-
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Adjuster {
-        return Adjuster{
-            .inner = @ptrCast(?*c.Fl_Adjuster, ptr),
-        };
-    }
-
-    pub fn toVoidPtr(self: *const Adjuster) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Adjuster) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asValuator(self: *const Adjuster) Valuator {
-        return Valuator{
-            .inner = @ptrCast(?*c.Fl_Adjuster, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Adjuster, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Adjuster_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Adjuster, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Adjuster_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
+pub const CounterType = enum(i32) {
+    /// Normal counter
+    Normal = 0,
+    /// Simple counter
+    Simple = 1,
 };
 
-pub const Roller = struct {
-    inner: ?*c.Fl_Roller,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Roller {
-        const ptr = c.Fl_Roller_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Roller{
-            .inner = ptr,
+pub fn Valuator(comptime kind: ValuatorKind) type {
+    return struct {
+        const Self = @This();
+
+        pub usingnamespace zfltk.widget.methods(Self, RawPtr);
+        pub usingnamespace methods(Self);
+
+        pub const RawPtr = switch (kind) {
+            .slider => *c.Fl_Slider,
+            .dial => *c.Fl_Dial,
+            .counter => *c.Fl_Counter,
+            .scrollbar => *c.Fl_Scrollbar,
+            .adjuster => *c.Fl_Adjuster,
+            .roller => *c.Fl_Roller,
         };
-    }
 
-    pub fn raw(self: *const Roller) ?*c.Fl_Roller {
-        return self.inner;
-    }
+        pub const Options = struct {
+            x: i32 = 0,
+            y: i32 = 0,
+            w: u31 = 0,
+            h: u31 = 0,
 
-    pub fn fromRaw(ptr: ?*c.Fl_Roller) Roller {
-        return Roller{
-            .inner = ptr,
+            label: ?[:0]const u8 = null,
+
+            orientation: Orientation = switch (kind) {
+                .slider, .scrollbar => .vertical,
+
+                else => .FILLER,
+            },
+
+            style: Style = switch (kind) {
+                .slider, .scrollbar, .counter => .normal,
+
+                else => .FILLER,
+            },
+
+            pub const Orientation = switch (kind) {
+                .slider, .scrollbar => enum(c_int) {
+                    vertical = 0,
+                    horizontal = 1,
+                },
+
+                else => enum(c_int) { FILLER = 0 },
+            };
+
+            pub const Style = switch (kind) {
+                .slider, .scrollbar => enum(c_int) {
+                    normal = 0,
+                    fill = 2,
+                    nice = 4,
+                },
+
+                .counter => enum(c_int) {
+                    normal = 0,
+                    simple = 1,
+                },
+
+                else => enum(c_int) { FILLER = 0 },
+            };
         };
-    }
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Roller {
-        return Roller{
-            .inner = @ptrCast(?*c.Fl_Roller, w),
-        };
-    }
+        pub inline fn init(opts: Options) !*Self {
+            const initFn = switch (kind) {
+                .slider => c.Fl_Slider_new,
+                .dial => c.Fl_Dial_new,
+                .counter => c.Fl_Counter_new,
+                .scrollbar => c.Fl_Scrollbar_new,
+                .adjuster => c.Fl_Adjuster_new,
+                .roller => c.Fl_Roller_new,
+            };
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Roller {
-        return Roller{
-            .inner = @ptrCast(?*c.Fl_Roller, ptr),
-        };
-    }
+            const label = if (opts.label != null) opts.label.?.ptr else null;
 
-    pub fn toVoidPtr(self: *const Roller) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
+            if (initFn(opts.x, opts.y, opts.w, opts.h, label)) |ptr| {
+                var self = Self.fromRaw(ptr);
 
-    pub fn asWidget(self: *const Roller) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
+                const orientation = @enumToInt(opts.orientation);
+                const style = @enumToInt(opts.style);
 
-    pub fn asValuator(self: *const Roller) Valuator {
-        return Valuator{
-            .inner = @ptrCast(?*c.Fl_Roller, self.inner),
-        };
-    }
+                c.Fl_Widget_set_type(self.widget().raw(), orientation + style);
 
-    pub fn handle(self: *const Roller, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Roller_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
+                return self;
+            }
 
-    pub fn draw(self: *const Roller, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Roller_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-};
+            unreachable;
+        }
+    };
+}
+
+pub fn methods(comptime Self: type) type {
+    return struct {
+        pub inline fn valuator(self: *Self) *Valuator(.slider) {
+            return @ptrCast(*Valuator(.slider), self);
+        }
+
+        //        pub fn handle(self: *const Self, cb: fn (w: Widget.RawPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
+        //            c.Fl_Slider_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
+        //        }
+        //
+        //        pub fn draw(self: *const Self, cb: fn (w: Widget.RawPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+        //            c.Fl_Slider_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
+        //        }
+
+        pub inline fn setBounds(self: *Self, a: f64, b: f64) void {
+            return c.Fl_Slider_set_bounds(self.valuator().raw(), a, b);
+        }
+
+        pub inline fn minimum(self: *Self) f64 {
+            return c.Fl_Slider_minimum(self.valuator().raw());
+        }
+
+        pub inline fn setMinimum(self: *Self, a: f64) void {
+            c.Fl_Slider_set_minimum(self.valuator().raw(), a);
+        }
+
+        pub inline fn maximum(self: *Self) f64 {
+            return c.Fl_Slider_maximum(self.valuator().raw());
+        }
+
+        pub inline fn setMaximum(self: *Self, a: f64) void {
+            c.Fl_Slider_set_maximum(self.valuator().raw(), a);
+        }
+
+        pub inline fn setRange(self: *Self, a: f64, b: f64) void {
+            return c.Fl_Slider_set_range(self.valuator().raw(), a, b);
+        }
+
+        pub inline fn setStep(self: *Self, a: f64, b: i32) void {
+            return c.Fl_Slider_set_step(self.valuator().raw(), a, b);
+        }
+
+        pub inline fn step(self: *Self) f64 {
+            return c.Fl_Slider_step(self.valuator().raw());
+        }
+
+        pub inline fn setPrecision(self: *Self, digits: i32) void {
+            return c.Fl_Slider_set_precision(self.valuator().raw(), digits);
+        }
+
+        pub inline fn value(self: *Self) f64 {
+            return c.Fl_Slider_value(self.valuator().raw());
+        }
+
+        pub inline fn setValue(self: *Self, arg2: f64) void {
+            return c.Fl_Slider_set_value(self.valuator().raw(), arg2);
+        }
+
+        pub inline fn format(self: *Self, arg2: [*c]const u8) void {
+            return c.Fl_Slider_format(self.valuator().raw(), arg2);
+        }
+
+        pub inline fn round(self: *Self, arg2: f64) f64 {
+            return c.Fl_Slider_round(self.valuator().raw(), arg2);
+        }
+
+        pub inline fn clamp(self: *Self, arg2: f64) f64 {
+            return c.Fl_Slider_clamp(self.valuator().raw(), arg2);
+        }
+
+        pub inline fn increment(self: *Self, arg2: f64, arg3: i32) f64 {
+            return c.Fl_Slider_increment(self.valuator().raw(), arg2, arg3);
+        }
+    };
+}
 
 test "all" {
     @import("std").testing.refAllDecls(@This());

--- a/src/window.zig
+++ b/src/window.zig
@@ -1,90 +1,68 @@
-const c = @cImport({
-    @cInclude("cfl_window.h");
-});
-const widget = @import("widget.zig");
-const group = @import("group.zig");
-const enums = @import("enums.zig");
+const zfltk = @import("zfltk.zig");
+const app = zfltk.app;
+const c = zfltk.c;
+const Widget = zfltk.Widget;
+const Group = zfltk.Group;
+const enums = zfltk.enums;
 
 pub const Window = struct {
-    inner: ?*c.Fl_Double_Window,
-    pub fn new(x: i32, y: i32, w: i32, h: i32, title: [*c]const u8) Window {
-        const ptr = c.Fl_Double_Window_new(x, y, w, h, title);
-        if (ptr == null) unreachable;
-        return Window{
-            .inner = ptr,
-        };
-    }
+    // Expose methods from `inherited` structs
+    pub usingnamespace zfltk.widget.methods(Window, RawPtr);
+    pub usingnamespace zfltk.group.methods(Window);
+    pub usingnamespace methods(Window);
 
-    pub fn raw(self: *const Window) ?*c.Fl_Double_Window {
-        return self.inner;
-    }
+    pub const RawPtr = *c.Fl_Double_Window;
 
-    pub fn fromRaw(ptr: ?*c.Fl_Double_Window) Window {
-        return Window{
-            .inner = ptr,
-        };
-    }
+    pub inline fn init(opts: Widget.Options) !*Window {
+        const label = if (opts.label != null) opts.label.?.ptr else null;
 
-    pub fn fromWidgetPtr(w: widget.WidgetPtr) Window {
-        return Window{
-            .inner = @ptrCast(?*c.Fl_Double_Window, w),
-        };
-    }
+        if (c.Fl_Double_Window_new(opts.x, opts.y, opts.w, opts.h, label)) |ptr| {
+            return @ptrCast(*Window, ptr);
+        }
 
-    pub fn fromVoidPtr(ptr: ?*anyopaque) Window {
-        return Window{
-            .inner = @ptrCast(?*c.Fl_Double_Window, ptr),
-        };
+        unreachable;
     }
-
-    pub fn toVoidPtr(self: *const Window) ?*anyopaque {
-        return @ptrCast(?*anyopaque, self.inner);
-    }
-
-    pub fn asWidget(self: *const Window) widget.Widget {
-        return widget.Widget{
-            .inner = @ptrCast(widget.WidgetPtr, self.inner),
-        };
-    }
-
-    pub fn asGroup(self: *const Window) group.Group {
-        return group.Group{
-            .inner = @ptrCast(group.GroupPtr, self.inner),
-        };
-    }
-
-    pub fn handle(self: *const Window, cb: fn (w: widget.WidgetPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
-        c.Fl_Double_Window_handle(self.inner, @ptrCast(c.custom_handler_callback, cb), data);
-    }
-
-    pub fn draw(self: *const Window, cb: fn (w: widget.WidgetPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
-        c.Fl_Double_Window_handle(self.inner, @ptrCast(c.custom_draw_callback, cb), data);
-    }
-
-    pub fn sizeRange(self: *const Window, min_w: i32, min_h: i32, max_w: i32, max_h: i32) void {
-        return c.Fl_Double_Window_size_range(self.inner, min_w, min_h, max_w, max_h);
-    }
-
-    pub fn iconize(self: *const Window) void {
-        return c.Fl_Double_Window_iconize(self.inner);
-    }
-
-    pub fn freePosition(self: *const Window) void {
-        return c.Fl_Double_Window_free_position(self.inner);
-    }
-
-    pub fn setCursor(self: *const Window, cursor: enums.Cursor) void {
-        return c.Fl_Double_Window_set_cursor(self.inner, cursor);
-    }
-
-    pub fn makeModal(self: *const Window, val: bool) void {
-        return c.Fl_Double_Window_make_modal(self.inner, @boolToInt(val));
-    }
-
-    pub fn fullscreen(self: *const Window, val: bool) void {
-        return c.Fl_Double_Window_fullscreen(self.inner, @boolToInt(val));
+    
+    pub inline fn deinit(self: *Window) void {
+        c.Fl_Double_Window_delete(self.raw());
     }
 };
+
+pub fn methods(comptime Self: type) type {
+    return struct {
+        pub fn handle(self: *const Self, cb: fn (w: Widget.RawPtr, ev: i32, data: ?*anyopaque) callconv(.C) i32, data: ?*anyopaque) void {
+            c.Fl_Double_Window_handle(self.raw(), @ptrCast(c.custom_handler_callback, cb), data);
+        }
+
+        pub fn draw(self: *const Self, cb: fn (w: Widget.RawPtr, data: ?*anyopaque) callconv(.C) void, data: ?*anyopaque) void {
+            c.Fl_Double_Window_handle(self.raw(), @ptrCast(c.custom_draw_callback, cb), data);
+        }
+
+        pub fn setSizeRange(self: *const Self, min_w: u31, min_h: u31, max_w: u31, max_h: u31) void {
+            return c.Fl_Double_Window_size_range(self.raw(), min_w, min_h, max_w, max_h);
+        }
+
+        pub fn iconize(self: *Self) void {
+            c.Fl_Double_Window_iconize(self.raw());
+        }
+
+        pub fn freePosition(self: *Self) void {
+            c.Fl_Double_Window_free_position(self.raw());
+        }
+
+        pub fn setCursor(self: *Self, cursor: enums.Cursor) void {
+            return c.Fl_Double_Window_set_cursor(self.raw(), cursor);
+        }
+
+        pub fn makeModal(self: *Self, val: bool) void {
+            return c.Fl_Double_Window_make_modal(self.raw(), @boolToInt(val));
+        }
+
+        pub fn setFullscreen(self: *Window, val: bool) void {
+            return c.Fl_Double_Window_fullscreen(self.raw(), @boolToInt(val));
+        }
+    };
+}
 
 test "all" {
     @import("std").testing.refAllDecls(@This());

--- a/src/zfltk.zig
+++ b/src/zfltk.zig
@@ -1,3 +1,5 @@
+const std = @import("std");
+
 pub const app = @import("app.zig");
 pub const image = @import("image.zig");
 pub const widget = @import("widget.zig");
@@ -17,11 +19,63 @@ pub const table = @import("table.zig");
 pub const tree = @import("tree.zig");
 pub const draw = @import("draw.zig");
 
+pub const Image = image.Image;
+pub const Widget = widget.Widget;
+pub const Group = group.Group;
+pub const Window = window.Window;
+pub const Button = button.Button;
+pub const Box = box.Box;
+pub const Browser = browser.Browser;
+pub const Menu = menu.Menu;
+pub const MenuBar = menu.MenuBar;
+pub const Input = input.Input;
+pub const TextDisplay = text.TextDisplay;
+pub const TextBuffer = text.TextBuffer;
+pub const FileDialog = dialog.FileDialog;
+pub const Valuator = valuator.Valuator;
+
+pub const c = @cImport({
+    @cInclude("cfl.h");
+    @cInclude("cfl_widget.h");
+    @cInclude("cfl_box.h");
+    @cInclude("cfl_button.h");
+    @cInclude("cfl_window.h");
+    @cInclude("cfl_browser.h");
+    @cInclude("cfl_input.h");
+    @cInclude("cfl_text.h");
+    @cInclude("cfl_image.h");
+    @cInclude("cfl_enums.h");
+    @cInclude("cfl_dialog.h");
+    @cInclude("cfl_group.h");
+    @cInclude("cfl_draw.h");
+    @cInclude("cfl_valuator.h");
+});
+
 pub fn widgetCast(comptime T: type, wid: anytype) T {
     var t = T{ .inner = null };
     return T{
         .inner = @ptrCast(@TypeOf(t.inner), wid.inner),
     };
+}
+
+// TODO: improve helper function
+// currently can get it sorta working if `comptime T: type` is used as a param
+// but I currently can't figure out a way to verify the return value of
+// `x.widget()` is equal to type `Widget`. This would make any type with a decl
+// of the name `widget` pass the test, which is suboptimal
+pub fn isWidget(comptime T: type) bool {
+    if (T == *Widget) return true;
+
+    const tfo = @typeInfo(T);
+    if (tfo != .Pointer) return false;
+
+    const Child = tfo.Pointer.child;
+
+    if (!@hasDecl(Child, "widget")) {
+        return false;
+    }
+
+    return true;
 }
 
 test "all" {


### PR DESCRIPTION
This is a rather large change that should make the API feel much more idiomatic to Zig, covered in <https://github.com/MoAlyousef/zfltk/issues/11>

Almost all of the examples have been completely updated, except `editor.zig`, which has been changed enough to work, and `editormsgs.zig`, which I have not begun work on.

API changes:
 * Using an `options` struct over passing everything as function params, which allows easily adding optional params, along with foregoing unnecessary ones 
 * Grouping alike widgets into single instantiation functions, so `CheckButton` becomes `Buton(.check)`, reducing the amount of importing you need to do

Other changes:
 * Widgets are now empty structs, which expose their pointer upon calling `raw()` instead of using an internal pointer
 * Copied and pasted code greatly reduced with `usingnamespace` and comptime generics
 * Colors now use comptime to arrange the struct based on native endianness

There's still quite a bit of work to do and I'll continue working on it and updating with small PRs but it is now at a point where it should be usable for small projects