### PR TITLE
Fix macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: 0.11.0-dev.1183+2b9478ce1
+          version: 0.10.0
       - name: Build
         run: |
           git submodule update --init --recursive


### PR DESCRIPTION
MacOS had too new a version of Zig, which would cause the build to fail