### PR TITLE
Add tile group with example, rename setScollBar to setScrollbar 

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -11,7 +11,7 @@ pub const SdkOpts = struct {
     use_zig_cc: bool = false,
     use_fltk_config: bool = false,
     fn finalOpts(self: SdkOpts) utils.FinalOpts {
-        return utils.FinalOpts {
+        return utils.FinalOpts{
             .use_wayland = self.use_wayland,
             .system_jpeg = self.system_jpeg,
             .system_png = self.system_png,

--- a/build_utils.zig
+++ b/build_utils.zig
@@ -47,6 +47,7 @@ pub const examples = &[_]Example{
     Example.init("handle", "examples/handle.zig", "Handle example"),
     Example.init("flutterlike", "examples/flutterlike.zig", "Flutter-like example"),
     Example.init("glwin", "examples/glwin.zig", "OpenGL window example"),
+    Example.init("tile", "examples/tile.zig", "Tile group example"),
 };
 
 pub fn cfltk_build_from_source(b: *Build, finalize_cfltk: *Build.Step, install_prefix: []const u8, opts: FinalOpts) !void {
@@ -303,7 +304,7 @@ pub fn link_using_fltk_config(b: *Build, exe: *CompileStep, finalize_cfltk: *Bui
     });
     const proc = try std.ChildProcess.exec(.{
         .allocator = b.allocator,
-        .argv = &[_][]const u8{"fltk-config", "--use-images", "--use-gl", "--cflags"},
+        .argv = &[_][]const u8{ "fltk-config", "--use-images", "--use-gl", "--cflags" },
     });
     const out = proc.stdout;
     var cflags = std.ArrayList([]const u8).init(b.allocator);
@@ -343,7 +344,7 @@ pub fn link_using_fltk_config(b: *Build, exe: *CompileStep, finalize_cfltk: *Bui
     }
     const proc2 = try std.ChildProcess.exec(.{
         .allocator = b.allocator,
-        .argv = &[_][]const u8{"fltk-config", "--use-images", "--use-gl", "--ldflags"},
+        .argv = &[_][]const u8{ "fltk-config", "--use-images", "--use-gl", "--ldflags" },
     });
     const out2 = proc2.stdout;
     var lflags = std.ArrayList([]const u8).init(b.allocator);

--- a/examples/image.zig
+++ b/examples/image.zig
@@ -23,7 +23,7 @@ pub fn main() !void {
         .h = 140,
     });
 
-    scroll.setScrollBar(.vertical);
+    scroll.setScrollbar(.vertical);
 
     var mybox = try Box.init(.{
         .w = 400,

--- a/examples/tile.zig
+++ b/examples/tile.zig
@@ -1,0 +1,68 @@
+const zfltk = @import("zfltk");
+const app = zfltk.app;
+const Window = zfltk.Window;
+const Box = zfltk.Box;
+const Button = zfltk.Button;
+const Group = zfltk.Group;
+const Color = enums.Color;
+const enums = zfltk.enums;
+
+pub fn main() !void {
+    try app.init();
+
+    var win = try Window.init(.{
+        .w = 400,
+        .h = 300,
+
+        .label = "Tile group",
+    });
+
+    var tile = try Group(.tile).init(.{
+        .w = 400,
+        .h = 300,
+    });
+
+    win.resizable(tile);
+
+    var btn = try Button(.normal).init(.{
+        .x = 0,
+        .y = 48,
+        .w = tile.w() - 48,
+        .h = 48,
+        .label = "Button",
+    });
+
+    // This demonstrates how you can add inline widgets which have no purpose
+    // besides aesthetics. This could be useful for spacers and whatnot
+    tile.add(.{
+        try Box.init(.{
+            .x = 0,
+            .y = 0,
+            .w = tile.w() - 48,
+            .h = 48,
+            .boxtype = .down,
+        }),
+        btn,
+        try Box.init(.{
+            .x = 0,
+            .y = 96,
+            .w = tile.w() - 48,
+            .h = tile.h() - 96,
+            .boxtype = .down,
+            .label = "Try dragging between\nwidget borders!",
+        }),
+        try Box.init(.{
+            .x = tile.w() - 48,
+            .y = 0,
+            .w = 48,
+            .h = tile.h(),
+            .boxtype = .down,
+        }),
+    });
+
+    tile.end();
+
+    win.end();
+    win.show();
+    try app.run();
+}

--- a/src/group.zig
+++ b/src/group.zig
@@ -15,6 +15,7 @@ pub const GroupKind = enum {
     tabs,
     scroll,
     flex,
+    tile,
 };
 
 pub const ScrollType = enum(c_int) {
@@ -52,13 +53,14 @@ pub fn Group(comptime kind: GroupKind) type {
             .tabs => *c.Fl_Tabs,
             .scroll => *c.Fl_Scroll,
             .flex => *c.Fl_Flex,
+            .tile => *c.Fl_Tile,
         };
         const type_name = @typeName(RawPtr);
         const ptr_name = type_name[(std.mem.indexOf(u8, type_name, "struct_Fl_") orelse 0) + 7 .. type_name.len];
 
         pub const Options = struct {
-            x: u31 = 0,
-            y: u31 = 0,
+            x: i32 = 0,
+            y: i32 = 0,
             w: u31 = 0,
             h: u31 = 0,
 
@@ -85,7 +87,7 @@ pub fn Group(comptime kind: GroupKind) type {
                     .pack, .flex => {
                         self.setSpacing(opts.spacing);
 
-                        if (opts.orientation != .vertical) {
+                        if (opts.orientation == .horizontal) {
                             c.Fl_Widget_set_type(self.widget().raw(), 1);
                         }
                     },
@@ -245,12 +247,20 @@ pub fn methods(comptime Self: type, comptime RawPtr: type) type {
             marginsFn(self.raw(), @intCast(left), @intCast(top), @intCast(right), @intCast(bottom));
         }
 
-        pub inline fn setScrollBar(self: *Self, scrollbar: ScrollType) void {
+        pub inline fn setScrollbar(self: *Self, scrollbar: ScrollType) void {
             if (Self != Group(.scroll)) {
-                @compileError("method `setScrollBar` only usable with scroll groups");
+                @compileError("method `setScrollbar` only usable with scroll groups");
             }
 
             self.setKind(ScrollType, scrollbar);
+        }
+
+        pub inline fn setScrollbarSize(self: *Self, size: u31) void {
+            if (Self != Group(.scroll)) {
+                @compileError("method `setScrollbarSize` only usable with scroll groups");
+            }
+
+            c.Fl_Scroll_set_scrollbar_size(self.raw(), size);
         }
     };
 }

--- a/src/image.zig
+++ b/src/image.zig
@@ -48,7 +48,6 @@ pub const Image = struct {
     };
 
     pub const Kind = enum {
-        normal,
         shared,
         svg,
         jpeg,
@@ -82,7 +81,7 @@ pub const Image = struct {
             else => unreachable,
         };
 
-        _ = switch (kind) {
+        switch (kind) {
             .shared => {
                 if (loadFn(path.ptr, 0, 0)) |ptr| {
                     try ImageErrorFromInt(failFn(ptr));
@@ -95,7 +94,7 @@ pub const Image = struct {
                     return Image.fromRaw(@ptrCast(ptr));
                 }
             },
-        };
+        }
 
         unreachable;
     }

--- a/src/widget.zig
+++ b/src/widget.zig
@@ -13,8 +13,8 @@ pub const Widget = struct {
     pub fn OptionsImpl(comptime ctx: type) type {
         _ = ctx;
         return struct {
-            x: u31 = 0,
-            y: u31 = 0,
+            x: i32 = 0,
+            y: i32 = 0,
             w: u31 = 0,
             h: u31 = 0,
 
@@ -315,7 +315,7 @@ pub fn methods(comptime Self: type, comptime RawPtr: type) type {
                 var allocator = std.heap.c_allocator;
                 var container = allocator.alloc(usize, 2) catch unreachable;
 
-                container[0] = @intFromPtr(f);
+                container[0] = @intFromPtr(&f);
                 container[1] = @intFromPtr(d);
 
                 @field(c, ptr_name ++ "_draw")(

--- a/src/widget.zig
+++ b/src/widget.zig
@@ -315,7 +315,7 @@ pub fn methods(comptime Self: type, comptime RawPtr: type) type {
                 var allocator = std.heap.c_allocator;
                 var container = allocator.alloc(usize, 2) catch unreachable;
 
-                container[0] = @intFromPtr(&f);
+                container[0] = @intFromPtr(f);
                 container[1] = @intFromPtr(d);
 
                 @field(c, ptr_name ++ "_draw")(


### PR DESCRIPTION
This PR also includes the following other changes:
 * Removal of old comments
 * Formatting with zig fmt
 * Refactoring of a couple lines to make them more readable
 * Addition of `Group.setScollbarSize` method
 * Fix a couple types

The thinking behind allowing signed X and Y values allows widgets to be
pushed off-screen, which makes sense for animations and whatnot.
However, negative sizes are undefined, so negative W and H should never
be allowed. My guess as to why FLTK uses `int` for all 4 values is
probably just because it's an easier type to work in C++ with than `unsigned
int` without requiring constant casting