### PR TITLE
Fix setting the text color of Inputs/Outputs

### DIFF
--- a/src/input.zig
+++ b/src/input.zig
@@ -100,7 +100,7 @@ fn InputType(comptime kind: InputKind) type {
         }
 
         pub fn setTextColor(self: *Input, col: Color) void {
-            c.Fl_Input_set_text_color(self.input().raw(), col.input().raw()());
+            c.Fl_Input_set_text_color(self.input().raw(), col.toRgbi());
         }
 
         pub fn setTextSize(self: *Input, sz: i32) void {

--- a/src/output.zig
+++ b/src/output.zig
@@ -85,7 +85,7 @@ fn OutputType(comptime kind: OutputKind) type {
         }
 
         pub fn setTextColor(self: *Output, col: Color) void {
-            c.Fl_Output_set_text_color(self.input().raw(), col.input().raw()());
+            c.Fl_Output_set_text_color(self.input().raw(), col.toRgbi());
         }
 
         pub fn setTextSize(self: *Output, sz: i32) void {


### PR DESCRIPTION
This PR fixes the setTextColor functions of both Input and Output, which are making calls to a function of Color that does not exist.