### PR TITLE
Add lib64 path in build_utils.zig

### DIFF
--- a/build_utils.zig
+++ b/build_utils.zig
@@ -215,6 +215,8 @@ pub fn cfltk_link(exe: *CompileStep, install_prefix: []const u8, opts: FinalOpts
     exe.addIncludePath(.{ .path = inc_dir });
     const lib_dir = try std.fmt.bufPrint(buf[0..], "{s}/cfltk/lib/lib", .{install_prefix});
     exe.addLibraryPath(.{ .path = lib_dir });
+    const lib64_dir = try std.fmt.bufPrint(buf[0..], "{s}/cfltk/lib/lib64", .{install_prefix});
+    exe.addLibraryPath(.{ .path = lib64_dir });
     exe.linkSystemLibrary("cfltk");
     exe.linkSystemLibrary("fltk");
     exe.linkSystemLibrary("fltk_images");


### PR DESCRIPTION
Hello there!

I recently picked up interest in FLTK, and I saw your Zig bindings so I wanted to try them. Unfortunately, they didn't quite work for me out of the box: Zig wouldn't find the libraries.

After some quick digging, I found out that they were being put in `zig-out/cfltk/lib/lib64`, instead of `zig-out/cfltk/lib/lib`, on my **Fedora 40** install. Thus, this PR adds the former path as a library path in `build_utils.zig`. I checked and it shouldn't cause any problem if the directory doesn't exist.